### PR TITLE
Add a wait state for database initialization

### DIFF
--- a/fix/__init__.py
+++ b/fix/__init__.py
@@ -23,6 +23,7 @@ except:
     from PyQt4.QtCore import *
 
 import logging
+import threading
 from datetime import datetime
 
 from . import client
@@ -261,7 +262,6 @@ class DB_Item(QObject):
             self.failChanged.emit(self._fail)
 
 
-
 # This Class represents the database itself.  Once instantiated it
 # creates and starts the thread that handles all the communication to
 # the server.
@@ -270,6 +270,7 @@ class Database(object):
         self.__items = {}
         global log
         log = logging.getLogger(__name__)
+        self.init_event = threading.Event()
 
         self.clientthread = client.ClientThread(host, port, self)
         self.clientthread.start()
@@ -322,7 +323,9 @@ class Database(object):
     # If the create flag is set to True this function will create an
     # item with the given key if it does not exist.  Otherwise just
     # return the item if found.
-    def get_item(self, key, create=False):
+    def get_item(self, key, wait=True, create=False):
+        if wait:
+            self.init_event.wait()
         try:
             return self.__items[key]
         except KeyError:

--- a/fix/client.py
+++ b/fix/client.py
@@ -107,6 +107,8 @@ class ClientThread(threading.Thread):
                     log.debug("Problem with ID list message")
                 else:
                     y = x[2].split(',')  # break up the list of Ids
+                    self.itemInitCount = len(y)
+                    log.debug("Waiting for {} database item definitions".format(self.itemInitCount))
                     for each in y:
                         log.debug("Requesting a report for {0}".format(each))
                         self.sendthread.queue.put("@q{0}\n".format(each).encode())
@@ -131,6 +133,10 @@ class ClientThread(threading.Thread):
                 self.handle_value(d[2:])
             elif d[1] == 'q':
                 self.db.define_item(key, x[1], x[2], x[3], x[4], x[5], x[6], x[7])
+                self.itemInitCount -= 1
+                if self.itemInitCount == 0:
+                    log.debug("Done Initializing Database")
+                    self.db.init_event.set()
 
         else:  # If no '@' then it must be a value update
             try:

--- a/instruments/ai/VirtualVfr.py
+++ b/instruments/ai/VirtualVfr.py
@@ -53,13 +53,13 @@ class VirtualVfr(AI):
         super(VirtualVfr, self).__init__(parent)
         self.display_objects = dict()
         time.sleep(.4)      # Pause to let DB load
-        lng = fix.db.get_item("LONG", True)
+        lng = fix.db.get_item("LONG")
         lng.valueChanged[float].connect(self.setLongitude)
-        lat = fix.db.get_item("LAT", True)
+        lat = fix.db.get_item("LAT")
         lat.valueChanged[float].connect(self.setLatitude)
-        head = fix.db.get_item("HEAD", True)
+        head = fix.db.get_item("HEAD")
         head.valueChanged[float].connect(self.setHeading)
-        alt = fix.db.get_item("ALT", True)
+        alt = fix.db.get_item("ALT")
         alt.valueChanged[float].connect(self.setAltitude)
         self.last_mag_update = 0
         self.magnetic_declination = None

--- a/instruments/ai/__init__.py
+++ b/instruments/ai/__init__.py
@@ -42,15 +42,15 @@ class AI(QGraphicsView):
         # Number of degrees shown from top to bottom
         self.pitchDegreesShown = 60
 
-        pitch = fix.db.get_item("PITCH", True)
+        pitch = fix.db.get_item("PITCH")
         pitch.valueChanged[float].connect(self.setPitchAngle)
         self._pitchAngle = pitch.value
-        roll = fix.db.get_item("ROLL", True)
+        roll = fix.db.get_item("ROLL")
         roll.valueChanged[float].connect(self.setRollAngle)
         self._rollAngle = roll.value
-        self.fdrolldb = fix.db.get_item("FDROLL", True)
-        self.fdpitchdb = fix.db.get_item("FDPITCH", True)
-        self.fdondb = fix.db.get_item("FDON", True)
+        self.fdrolldb = fix.db.get_item("FDROLL", wait=False, create=True)
+        self.fdpitchdb = fix.db.get_item("FDPITCH", wait=False, create=True)
+        self.fdondb = fix.db.get_item("FDON", wait=False, create=True)
         self.fdondb.valueChanged[bool].connect(self.fdon)
         self.fdtarget_widget = None
         self.fdt = None

--- a/instruments/airspeed/__init__.py
+++ b/instruments/airspeed/__init__.py
@@ -37,7 +37,7 @@ class Airspeed(QWidget):
         self.setFocusPolicy(Qt.NoFocus)
         self.fontsize = 20
         self._airspeed = 0
-        fix.db.get_item("IAS", True).valueChanged[float].connect(self.setAirspeed)
+        fix.db.get_item("IAS").valueChanged[float].connect(self.setAirspeed)
 
 
     def paintEvent(self, event):
@@ -158,7 +158,7 @@ class Airspeed_Tape(QGraphicsView):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setRenderHint(QPainter.Antialiasing)
         self.setFocusPolicy(Qt.NoFocus)
-        item = fix.db.get_item("IAS", True)
+        item = fix.db.get_item("IAS")
         item.valueChanged[float].connect(self.setAirspeed)
         self._airspeed = item.value
 

--- a/instruments/altimeter/__init__.py
+++ b/instruments/altimeter/__init__.py
@@ -33,7 +33,7 @@ class Altimeter(QWidget):
         self.setStyleSheet("border: 0px")
         self.setFocusPolicy(Qt.NoFocus)
         self._altimeter = 0
-        fix.db.get_item("ALT", True).valueChanged[float].connect(self.setAltimeter)
+        fix.db.get_item("ALT").valueChanged[float].connect(self.setAltimeter)
 
     # TODO We continuously draw things that don't change.  Should draw the
     # background save to pixmap or something and then blit it and draw arrows.
@@ -125,7 +125,7 @@ class Altimeter_Tape(QGraphicsView):
         self.setRenderHint(QPainter.Antialiasing)
         self.setFocusPolicy(Qt.NoFocus)
         self.fontsize = 15
-        item = fix.db.get_item("ALT", True)
+        item = fix.db.get_item("ALT")
         self._altimeter = item.value
         self.maxalt = maxalt
         self.pph = 0.3
@@ -215,7 +215,7 @@ class Altimeter_Setting(QGraphicsView):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setRenderHint(QPainter.Antialiasing)
         self.setFocusPolicy(Qt.NoFocus)
-        item1 = fix.db.get_item("BARO", True)
+        item1 = fix.db.get_item("BARO")
         self._altimeter_setting = item1.value
         item1.valueChanged[float].connect(self.setAltimeter_Setting)
 

--- a/instruments/gauges/__init__.py
+++ b/instruments/gauges/__init__.py
@@ -126,7 +126,7 @@ class AbstractGauge(QWidget):
         # If this doesn't exist it will be a silent error.  We either have to
         # set the create flag to true or risk that we'll start before the database
         # is fully initialized.
-        item = fix.db.get_item(key, True)
+        item = fix.db.get_item(key)
         item.auxChanged.connect(self.setAuxData)
         item.reportReceived.connect(self.setupGauge)
         item.annunciateChanged.connect(self.annunciateFlag)
@@ -154,7 +154,7 @@ class AbstractGauge(QWidget):
     # This should get called when the gauge is created and then again
     # anytime a new report of the db item is recieved from the server
     def setupGauge(self):
-        item = fix.db.get_item(self.dbkey, True)
+        item = fix.db.get_item(self.dbkey)
         # min and max should always be set for FIX Gateway data.
         if item.min: self.lowRange = item.min
         if item.max: self.highRange = item.max

--- a/instruments/hsi/__init__.py
+++ b/instruments/hsi/__init__.py
@@ -33,23 +33,23 @@ class HSI(QWidget):
         self.fg_color = fgcolor
         self.bg_color = bgcolor
         self._heading_key = None
-        item = fix.db.get_item("COURSE", True)
+        item = fix.db.get_item("COURSE")
         self._headingSelect = item.value
         item.valueChanged[float].connect(self.setHeadingBug)
         self._courseSelect = 1
 
-        self.cdidb = fix.db.get_item("CDI", True)
+        self.cdidb = fix.db.get_item("CDI")
         self._courseDeviation = self.cdidb.value
         self.cdidb.valueChanged[float].connect(self.setCdi)
         self._showCDI = not self.cdidb.old
 
-        self.gsidb = fix.db.get_item("GSI", True)
+        self.gsidb = fix.db.get_item("GSI")
         self._glideSlopeIndicator = self.gsidb.value
         self.gsidb.valueChanged[float].connect(self.setGsi)
         self._showGSI = not self.gsidb.old
         self.cardinal = ["N", "E", "S", "W"]
 
-        item = fix.db.get_item("HEAD", True)
+        item = fix.db.get_item("HEAD")
         self._heading = item.value
         item.valueChanged[float].connect(self.setHeading)
 
@@ -167,13 +167,13 @@ class HSI(QWidget):
             x = self.cx + self._courseDeviation * self.cdippw
             c.drawLine(x, self.cy + self.r - self.fontSize*2 - 6,
                    x, self.cy - self.r + self.fontSize*2 + 6)
-            
+
         self._showGSI = not self.gsidb.old
         if self._showGSI:
             y = self.cy - self._glideSlopeIndicator * self.gsipph
             c.drawLine(self.cx + self.r - self.fontSize*2 - 6, y,
                    self.cx - self.r + self.fontSize*2 + 6, y)
-            
+
 
     def getHeading(self):
         return self._heading

--- a/instruments/tc/__init__.py
+++ b/instruments/tc/__init__.py
@@ -33,7 +33,7 @@ class TurnCoordinator(QWidget):
         self.setFocusPolicy(Qt.NoFocus)
         self._rate = 0.0
         self._latAcc = 0.0
-        item = fix.db.get_item("ALAT", True)
+        item = fix.db.get_item("ALAT")
         item.valueChanged[float].connect(self.setLatAcc)
 
     def resizeEvent(self, event):

--- a/instruments/vsi/__init__.py
+++ b/instruments/vsi/__init__.py
@@ -35,7 +35,7 @@ class VSI(QWidget):
         self._roc = 0
         self.maxRange = 2000
         self.maxAngle = 170.0
-        item = fix.db.get_item("VS", True)
+        item = fix.db.get_item("VS")
         item.valueChanged[float].connect(self.setROC)
 
     def resizeEvent(self, event):
@@ -240,7 +240,7 @@ class Alt_Trend_Tape(QGraphicsView):
         self.setRenderHint(QPainter.Antialiasing)
         self.setFocusPolicy(Qt.NoFocus)
 
-        item = fix.db.get_item("VS", True)
+        item = fix.db.get_item("VS")
         item.valueChanged[float].connect(self.setVs)
         self._vs = item.value
         self.maxvs = 2500

--- a/screens/pfd.py
+++ b/screens/pfd.py
@@ -84,7 +84,7 @@ class Screen(QWidget):
         self.fuel = gauges.HorizontalBar(self)
         self.fuel.name = "Fuel Qty"
         self.fuel.decimalPlaces = 1
-        self.fuel.dbkey = "FUELQ"
+        self.fuel.dbkey = "FUELQT"
 
         self.ff = gauges.HorizontalBar(self)
         self.ff.name = "Fuel Flow"
@@ -97,7 +97,7 @@ class Screen(QWidget):
         self.cht.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
         # This causes the units sent from the server to be overridden
         self.cht.unitsOverride = u'\N{DEGREE SIGN}F'
-        self.cht.dbkey = "CHTMAX"
+        self.cht.dbkey = "CHTMAX1"
 
         self.egt = gauges.HorizontalBar(self)
         self.egt.name = "Avg EGT"
@@ -106,7 +106,7 @@ class Screen(QWidget):
         # This causes the units sent from the server to be overridden
         self.egt.unitsOverride = u'\N{DEGREE SIGN}F'
         self.egt.decimalPlaces = 0
-        self.egt.dbkey = "EGTAVG"
+        self.egt.dbkey = "EGTAVG1"
 
 
 

--- a/screens/pfd_sm.py
+++ b/screens/pfd_sm.py
@@ -82,7 +82,7 @@ class Screen(QWidget):
         self.fuel = gauges.HorizontalBar(self)
         self.fuel.name = "Fuel Qty"
         self.fuel.decimalPlaces = 1
-        self.fuel.dbkey = "FUELQ"
+        self.fuel.dbkey = "FUELQT"
 
         self.ff = gauges.HorizontalBar(self)
         self.ff.name = "Fuel Flow"
@@ -95,7 +95,7 @@ class Screen(QWidget):
         self.cht.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
         # This causes the units sent from the server to be overridden
         self.cht.unitsOverride = u'\N{DEGREE SIGN}F'
-        self.cht.dbkey = "CHTMAX"
+        self.cht.dbkey = "CHTMAX1"
 
         self.egt = gauges.HorizontalBar(self)
         self.egt.name = "Avg EGT"
@@ -104,7 +104,7 @@ class Screen(QWidget):
         # This causes the units sent from the server to be overridden
         self.egt.unitsOverride = u'\N{DEGREE SIGN}F'
         self.egt.decimalPlaces = 0
-        self.egt.dbkey = "EGTAVG"
+        self.egt.dbkey = "EGTAVG1"
 
 
 

--- a/user/hooks/composite.py
+++ b/user/hooks/composite.py
@@ -25,11 +25,11 @@ class CompositeFloatItem(object):
     def __init__(self, key, itemkeys):
         self.key = key # This is our key name
         self.items = []
-        self.item = fix.db.get_item(key, create = True)
+        self.item = fix.db.get_item(key)
         self.item.type = 'float'
 
         for key in itemkeys:
-            item = fix.db.get_item(key, create = True)
+            item = fix.db.get_item(key)
             self.items.append(item)
             item.valueChanged[float].connect(self.calcValue)
             #valueWrite = pyqtSignal([float],[int],[bool],[str])
@@ -147,7 +147,7 @@ class CompositeMaxItem(CompositeFloatItem):
 
 
 
-fuel_total = CompositeSumItem("FUELQ", ["FUELQ1", "FUELQ2"])
+fuel_total = CompositeSumItem("FUELQT", ["FUELQ1", "FUELQ2"])
 # TODO Should have a way to do this automatically if needed
 fuel_total.item.min = 0.0
 fuel_total.item.max = 42.0
@@ -158,8 +158,8 @@ fuel_total.item.aux["lowAlarm"] = 2.0
 fuel_total.item.aux["highAlarm"] = 42.0
 fuel_total.setup() # Force an update
 
-cht_max = CompositeMaxItem("CHTMAX", ["CHT11", "CHT12", "CHT13", "CHT14"])
+cht_max = CompositeMaxItem("CHTMAX1", ["CHT11", "CHT12", "CHT13", "CHT14"])
 cht_max.setup()
 
-egt_avg = CompositeAvgItem("EGTAVG", ["EGT11", "EGT12", "EGT13", "EGT14"])
+egt_avg = CompositeAvgItem("EGTAVG1", ["EGT11", "EGT12", "EGT13", "EGT14"])
 egt_avg.setup()


### PR DESCRIPTION
Calls to db.get_item() will now wait until all of the database items
have been created based on the list from the FIX server.

Fixes #58 