### PR TITLE
Fix imports for new pyavtools package

### DIFF
--- a/config/beagle.yaml
+++ b/config/beagle.yaml
@@ -9,7 +9,7 @@ main:
   screenHeight: 480
 
   # Set EFIS to occupy the entire screen without system border / menu
-  screenFullSize: True
+  screenFullSize: False 
 
   # Screen background color RGB
   screenColor: (0,0,0)

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -9,7 +9,7 @@ main:
   screenHeight: 768
 
   # Set EFIS to occupy the entire screen without system border / menu
-  screenFullSize: True
+  screenFullSize: False
 
   # Screen background color RGB
   screenColor: (0,0,0)

--- a/hmi/data.py
+++ b/hmi/data.py
@@ -25,7 +25,7 @@ import operator
 import logging
 log = logging.getLogger(__name__)
 
-import fix
+import pyavtools.fix as fix
 import hmi
 
 __bindings = []

--- a/hmi/functions.py
+++ b/hmi/functions.py
@@ -14,7 +14,7 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-import fix
+import pyavtools.fix as fix
 
 # Set a value in the FIX database.  arg should be "key,value"
 def setValue(arg):

--- a/hmi/menu.py
+++ b/hmi/menu.py
@@ -25,7 +25,7 @@ except:
 import logging
 
 #import hooks
-import fix
+import pyavtools.fix as fix
 import hmi
 
 logger=logging.getLogger(__name__)

--- a/instruments/ai/VirtualVfr.py
+++ b/instruments/ai/VirtualVfr.py
@@ -31,11 +31,11 @@ except:
 import efis
 import logging
 
-import fix
+import pyavtools.fix as fix
 
 from instruments.ai import AI
-import Spatial
-import CIFPObjects
+import pyavtools.Spatial as Spatial
+import pyavtools.CIFPObjects as CIFPObjects
 
 log = logging.getLogger(__name__)
 

--- a/instruments/ai/__init__.py
+++ b/instruments/ai/__init__.py
@@ -25,7 +25,7 @@ import math
 import efis
 import logging
 
-import fix
+import pyavtools.fix as fix
 
 log = logging.getLogger(__name__)
 

--- a/instruments/airspeed/__init__.py
+++ b/instruments/airspeed/__init__.py
@@ -24,7 +24,7 @@ except:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
-import fix
+import pyavtools.fix as fix
 import hmi
 from instruments.NumericalDisplay import NumericalDisplay
 

--- a/instruments/altimeter/__init__.py
+++ b/instruments/altimeter/__init__.py
@@ -23,7 +23,7 @@ except:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
-import fix
+import pyavtools.fix as fix
 
 from instruments.NumericalDisplay import NumericalDisplay
 

--- a/instruments/gauges/__init__.py
+++ b/instruments/gauges/__init__.py
@@ -24,7 +24,7 @@ except:
     from PyQt4.QtCore import *
 
 import efis
-import fix
+import pyavtools.fix as fix
 
 def drawCircle(p, x, y, r, start, end):
     rect = QRect(x - r, y - r, r * 2, r * 2)

--- a/instruments/hsi/__init__.py
+++ b/instruments/hsi/__init__.py
@@ -24,7 +24,7 @@ except:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 import efis
-import fix
+import pyavtools.fix as fix
 
 class HSI(QGraphicsView):
     def __init__(self, parent=None, font_size=15, fgcolor=Qt.black, bgcolor=Qt.white):

--- a/instruments/tc/__init__.py
+++ b/instruments/tc/__init__.py
@@ -23,7 +23,7 @@ except:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 import math
-import fix
+import pyavtools.fix as fix
 
 
 class TurnCoordinator(QWidget):

--- a/instruments/vsi/__init__.py
+++ b/instruments/vsi/__init__.py
@@ -23,7 +23,7 @@ except:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
-import fix
+import pyavtools.fix as fix
 
 
 class VSI(QWidget):

--- a/pyEfis.py
+++ b/pyEfis.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 #!/usr/bin/env python3
 
 #  Copyright (c) 2013 Phil Birkelbach
@@ -22,10 +21,6 @@ import sys, os
 import logging
 import logging.config
 import argparse
-# try:
-#     import ConfigParser
-# except:
-#     import configparser as ConfigParser
 try:
     from PyQt5.QtGui import *
     from PyQt5.QtWidgets import *
@@ -35,19 +30,7 @@ except:
     PYQT = 4
 import yaml
 
-if "pyAvTools" not in ''.join(sys.path):
-    neighbor_tools = os.path.join ('..', 'pyAvTools')
-    if os.path.isdir (neighbor_tools):
-        sys.path.append (neighbor_tools)
-    elif 'TOOLS_PATH' in os.environ:
-        sys.path.append (os.environ['TOOLS_PATH'])
-
-try:
-    import fix
-except:
-    print ("You need to have pyAvTools installed, or in an adjacent directory to pyEfis.")
-    print ("Or set the environment variable 'TOOLS_PATH' to point to the location of pyAvTools.")
-    sys.exit(-1)
+import pyavtools.fix as fix
 
 import hooks
 import hmi

--- a/user/hooks/composite.py
+++ b/user/hooks/composite.py
@@ -19,7 +19,7 @@
 
 # TODO This is not the cleanest mechanism.  It needs some love and thought
 
-import fix
+import pyavtools.fix as fix
 
 class CompositeFloatItem(object):
     def __init__(self, key, itemkeys):

--- a/user/hooks/keys.py
+++ b/user/hooks/keys.py
@@ -25,7 +25,7 @@ except:
 import logging
 
 import gui
-import fix
+import pyavtools.fix as fix
 import hooks
 from hmi import actions
 


### PR DESCRIPTION
I refactored pyAvTools to make it installable via setuptools and/or pip and these changes address the differences in how to import the modules that were moved there.