### PR TITLE
Ability to toggle units for non-savages

### DIFF
--- a/config/beagle.yaml
+++ b/config/beagle.yaml
@@ -9,7 +9,7 @@ main:
   screenHeight: 480
 
   # Set EFIS to occupy the entire screen without system border / menu
-  screenFullSize: False 
+  screenFullSize: False
 
   # Screen background color RGB
   screenColor: (0,0,0)
@@ -50,6 +50,10 @@ keybindings:
     action: Set Value
     args: BTN6, False
     direction: UP
+  - key: U
+    action: Set Instrument Units
+    args: OAT,OILT1,Temperature:Toggle
+
 
 # This section defines FIX IDs that we'll write out to the
 # FIX Gateway server.  Each can be defined as one of three
@@ -88,8 +92,8 @@ screens:
 # main window and default screen are shown.  We'll add more as the
 # need arises.
 hooks:
-  Keys:
-    module: user.hooks.keys
+#   Keys:
+#     module: user.hooks.keys
 #  Composite:
 #    module: user.hooks.composite
 

--- a/config/ems.yaml
+++ b/config/ems.yaml
@@ -45,6 +45,9 @@ keybindings:
   - key: R
     action: Set EGT Mode
     args: Reset Peak
+  - key: U
+    action: Set Instrument Units
+    args: OAT,OILT1,Temperature:Toggle
 
 
 # This section defines FIX IDs that we'll write out to the

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -53,6 +53,9 @@ keybindings:
     action: Set Value
     args: BTN6, False
     direction: UP
+  - key: U
+    action: Set Instrument Units
+    args: OAT,OILT1,Temperature:Toggle
 
   - key: F1
     action: Activate Menu Item
@@ -149,10 +152,10 @@ screens:
 # main window and default screen are shown.  We'll add more as the
 # need arises.
 hooks:
-  Keys:
-    module: user.hooks.keys
-  Composite:
-    module: user.hooks.composite
+  # Keys:
+  #   module: user.hooks.keys
+  # Composite:
+  #   module: user.hooks.composite
 
 
 # Logging configuration - See Python logging.config module documenation

--- a/hmi/actions.py
+++ b/hmi/actions.py
@@ -29,11 +29,14 @@ class ActionClass(QWidget):
     setAirspeedMode = pyqtSignal(object)
     setEgtMode = pyqtSignal(object)
     showScreen = pyqtSignal(object)
+    # arg = screen name
     showNextScreen = pyqtSignal(object)
     showPrevScreen = pyqtSignal(object)
     activateMenuItem = pyqtSignal(object)
     menuEncoder = pyqtSignal(object)
     setMenuFocus = pyqtSignal(object)
+    setInstUnits = pyqtSignal(object)
+    # arg = <inst name>,<inst name>,<inst name>,..:<Command>
 
 
     def __init__(self):
@@ -48,6 +51,7 @@ class ActionClass(QWidget):
                           "activate menu item":self.activateMenuItem,
                           "menu encoder":self.menuEncoder,
                           "set menu focus":self.setMenuFocus,
+                          "set instrument units":self.setInstUnits,
                           "evaluate":eval
                     }
 

--- a/instruments/gauges/egt.py
+++ b/instruments/gauges/egt.py
@@ -32,7 +32,7 @@ class EGTGroup(QWidget):
         super(EGTGroup, self).__init__(parent)
         self.setMinimumSize(50, 100)
         self.bars = []
-        self.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        #self.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
         self.normalizeMode = False
         self.peakMode = False
         for i in range(cylinders):
@@ -41,7 +41,12 @@ class EGTGroup(QWidget):
             bar.decimalPlaces = 0
             bar.showUnits = False
             bar.peakMode = False
-            bar.conversionFunction = self.conversionFunction
+            bar.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+            bar.conversionFunction2 = lambda x: x
+            bar.unitsOverride1 = u'\N{DEGREE SIGN}F'
+            bar.unitsOverride2 = u'\N{DEGREE SIGN}C'
+            bar.setUnitSwitching()
+            bar.unitGroup = "Temperature"
             bar.dbkey = dbkeys[i]
             bar.normalizeRange = 400
             self.bars.append(bar)

--- a/screens/ems_sm.py
+++ b/screens/ems_sm.py
@@ -57,9 +57,13 @@ class Screen(QWidget):
         self.ot = gauges.HorizontalBar(self)
         self.ot.name = "Oil Temp"
         # Use a lambda to convert the values internally
-        self.ot.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.ot.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.ot.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.ot.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.ot.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.ot.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.ot.setUnitSwitching()
+
         self.ot.decimalPlaces = 1
         self.ot.dbkey = "OILT1"
 
@@ -115,7 +119,12 @@ class Screen(QWidget):
 
             cht.name = str(x+1)
             cht.decimalPlaces = 0
-            cht.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+            cht.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+            cht.conversionFunction2 = lambda x: x
+            #cht.unitsOverride1 = u'\N{DEGREE SIGN}F'
+            #cht.unitsOverride2 = u'\N{DEGREE SIGN}C'
+            cht.unitGroup = "Temperature"
+            cht.setUnitSwitching()
             cht.showUnits = False
             cht.dbkey = "CHT1{}".format(x+1)
             self.chts.append(cht)
@@ -127,8 +136,12 @@ class Screen(QWidget):
         self.chtmax = gauges.NumericDisplay(self)
         self.chtmax.name = "CHT Max"
         self.chtmax.decimalPlaces = 0
-        self.chtmax.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
-        self.chtmax.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.chtmax.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.chtmax.conversionFunction2 = lambda x: x
+        self.chtmax.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.chtmax.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.chtmax.setUnitSwitching()
+        self.chtmax.unitGroup = "Temperature"
         self.chtmax.dbkey = "CHTMAX1"
 
         self.egt = misc.StaticText("EGT", parent=self)
@@ -152,9 +165,12 @@ class Screen(QWidget):
         self.oat.decimalPlaces = 1
         self.oat.dbkey = "OAT"
         self.oat.alignment = Qt.AlignLeft | Qt.AlignVCenter
-        self.oat.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
-        self.oat.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.oat.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.oat.conversionFunction2 = lambda x: x
+        self.oat.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.oat.unitsOverride2 = u'\N{DEGREE SIGN}C'
         self.oat.showUnits = True
+        self.oat.setUnitSwitching()
         self.oat.smallFontPercent = 0.6
 
         self.timez = misc.ValueDisplay(self)

--- a/screens/pfd.py
+++ b/screens/pfd.py
@@ -75,10 +75,12 @@ class Screen(QWidget):
         self.ot = gauges.HorizontalBar(self)
         self.ot.name = "Oil Temp"
         # Use a lambda to convert the values internally
-        self.ot.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.ot.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.ot.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.ot.unitsOverride = u'\N{DEGREE SIGN}F'
-        self.ot.decimalPlaces = 1
+        self.ot.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.ot.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.ot.setUnitSwitching()
         self.ot.dbkey = "OILT1"
 
 
@@ -95,20 +97,27 @@ class Screen(QWidget):
         self.cht = gauges.HorizontalBar(self)
         self.cht.name = "Max CHT"
         # Use a lambda to convert the values internally
-        self.cht.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.cht.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.cht.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.cht.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.cht.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.cht.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.cht.unitGroup = "Temperature"
+        self.cht.setUnitSwitching()
         self.cht.dbkey = "CHTMAX1"
 
         self.egt = gauges.HorizontalBar(self)
         self.egt.name = "Avg EGT"
         # Use a lambda to convert the values internally
-        self.egt.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.egt.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.egt.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.egt.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.egt.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.egt.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.egt.unitGroup = "Temperature"
+        self.egt.setUnitSwitching()
         self.egt.decimalPlaces = 0
         self.egt.dbkey = "EGTAVG1"
-
 
 
     def resizeEvent(self, event):

--- a/screens/pfd_sm.py
+++ b/screens/pfd_sm.py
@@ -72,10 +72,12 @@ class Screen(QWidget):
         self.ot = gauges.HorizontalBar(self)
         self.ot.name = "Oil Temp"
         # Use a lambda to convert the values internally
-        self.ot.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.ot.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.ot.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.ot.unitsOverride = u'\N{DEGREE SIGN}F'
-        self.ot.decimalPlaces = 1
+        self.ot.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.ot.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.ot.setUnitSwitching()
         self.ot.dbkey = "OILT1"
 
 
@@ -92,17 +94,25 @@ class Screen(QWidget):
         self.cht = gauges.HorizontalBar(self)
         self.cht.name = "Max CHT"
         # Use a lambda to convert the values internally
-        self.cht.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.cht.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.cht.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.cht.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.cht.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.cht.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.cht.unitGroup = "Temperature"
+        self.cht.setUnitSwitching()
         self.cht.dbkey = "CHTMAX1"
 
         self.egt = gauges.HorizontalBar(self)
         self.egt.name = "Avg EGT"
         # Use a lambda to convert the values internally
-        self.egt.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
+        self.egt.conversionFunction1 = lambda x: x * (9.0/5.0) + 32.0
+        self.egt.conversionFunction2 = lambda x: x
         # This causes the units sent from the server to be overridden
-        self.egt.unitsOverride = u'\N{DEGREE SIGN}F'
+        self.egt.unitsOverride1 = u'\N{DEGREE SIGN}F'
+        self.egt.unitsOverride2 = u'\N{DEGREE SIGN}C'
+        self.egt.unitGroup = "Temperature"
+        self.egt.setUnitSwitching()
         self.egt.decimalPlaces = 0
         self.egt.dbkey = "EGTAVG1"
 


### PR DESCRIPTION
Pressing 'u' should make the temperature units toggle between C and F.  This has the ability to toggle other units as well such as knots/mph or ft/meters or whatever if those instruments were modified to use the feature.