### PR TITLE
Decouple data from widgets and config driven screen builder

### DIFF
--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -7,7 +7,8 @@ main:
   #screenHeight: 768
   screenWidth: 800
   screenHeight: 480
-
+  #screenWidth: 3840
+  #screenHeight: 1100
   # Set EFIS to occupy the entire screen without system border / menu
   screenFullSize: True
 
@@ -225,50 +226,112 @@ screens:
         column: 21
         span:
           rows: 3
-          columns: 7
+          columns: 27
         options:
           name: Oil Temp
           decPlaces: 1
 
       -
-        type: vertical_bar_gauge
-        db_item: VOLT
+        type: ganged_vertical_bar_gauge
+        #db_item: VOLT
         row: 8
         column: 1
         span:
           rows: 5
-          columns: 2
-        options:
-          name: Volt
-          decPlaces: 1
-          showUnits: false
-      -
-        type: vertical_bar_gauge
-        db_item: CURRNT
-        row: 8
-        column: 3
-        span:
-          rows: 5
-          columns: 2
-        options:
-          name: Amp
-          decPlaces: 1
-          showUnits: false
+          columns: 27
+        groups:
+          - name: Power
+            instruments:
+              -
+                db_item: VOLT
+                options:
+                  name: Volt
+                  decPlaces: 1
+                  showUnits: false
+              -
+                db_item: CURRNT
+                options:
+                  name: Amp
+                  decPlaces: 1
+                  showUnits: false
+          - name: EGT
+            #options:
+            #  ???? highlight max?
+            instruments:
+              -
+                db_item: EGT11
+                options:
+                  name: "1"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: EGT12
+                options:
+                  name: "2"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: EGT13
+                options:
+                  name: "3"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: EGT14
+                options:
+                  name: "4"
+                  decPlaces: 0
+                  showUnits: false
+          - name: CHT
+            instruments:
+              -
+                db_item: CHT11
+                options:
+                  name: "1"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: CHT12
+                options:
+                  name: "2"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: CHT13
+                options:
+                  name: "3"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: CHT14
+                options:
+                  name: "4"
+                  decPlaces: 0
+                  showUnits: false
+          - name: FUEL
+            instruments:
+              -
+                db_item: FUELQ1
+                options:
+                  name: "Left"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: FUELQ2
+                options:
+                  name: "Center"
+                  decPlaces: 0
+                  showUnits: false
+              -
+                db_item: FUELQ1
+                options:
+                  name: "Right"
+                  decPlaces: 0
+                  showUnits: false
 
-      -
-        type: egt_vertical_bar_gauge
-        db_item: EGT
-        row: 8
-        column: 5
-        span:
-          rows: 5
-          columns: 7
-        options:
-          name: EGTs
-          decPlaces: 0
-          showUnits: false
-          cylinders: 4
-          engine: 1
+
+
+
   SixPack:
     module: pyefis.screens.sixpack
     title: Standard Instrument Panel

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -15,7 +15,7 @@ main:
   screenColor: (0,0,0)
 
   # If left out the first defined screen will be default
-  defaultScreen: EPFD
+  defaultScreen: SixPack
 
 menu:
   menus:
@@ -178,7 +178,21 @@ screens:
   SixPack:
     module: pyefis.screens.sixpack
     title: Standard Instrument Panel
-
+    layout:
+      type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
+      rows: 2
+      columns: 3
+    insturments:
+      -
+        type: altimeter_dial
+        db_items: ALT
+        row: 1
+        column: 3
+      -
+        type: vsi_dial
+        db_items: VS
+        row: 2
+        column: 3
   PFDSM:
     module: pyefis.screens.pfd_sm
     title: PFD Small

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -191,6 +191,14 @@ screens:
         db_items: IAS
         row: 1
         column: 1
+      - type: atitude_indicator
+        db_items:
+          - PITCH
+          - ROLL
+          - ALAT
+          - TAS
+        row: 1
+        column: 2
       -
         type: altimeter_dial
         db_items: ALT

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -207,33 +207,30 @@ screens:
           name: MAP
           decimalPlaces: 1          
       -
-        type: horizontal_bar_gauge
-        db_item: OILP1
+        type: ganged_horizontal_bar_gauge
+        gang_type: vertical
         row: 1
         column: 21
         span:
-          rows: 3
-          columns: 7
-        options:
-          name: Oil Press
-          decPlaces: 1
-          temperature: true
-          
-      -
-        type: horizontal_bar_gauge
-        db_item: OILT1
-        row: 4
-        column: 21
-        span:
-          rows: 3
-          columns: 27
-        options:
-          name: Oil Temp
-          decPlaces: 1
-
+          rows: 5
+          columns: 14
+        groups:
+          - name: Oil
+            instruments:
+              -
+                db_item: OILP1
+                options:
+                  name: Oil Press
+                  decPlaces: 1
+                  temperature: true
+              -
+                db_item: OILT1
+                options:
+                  name: Oil Temp
+                  decPlaces: 1
       -
         type: ganged_vertical_bar_gauge
-        #db_item: VOLT
+        gang_type: horizontal
         row: 8
         column: 1
         span:

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -175,6 +175,22 @@ screens:
     module: pyefis.screens.ems_sm
     title: Engine Management
 
+  EMSNew:
+    module: pyefis.screens.screenbuilder
+    title: Engine Management
+    layout:
+      type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
+      rows: 800
+      columns: 640
+    instruments:
+      -
+        type: arc_gauge
+        db_items: TACH1
+        row: 1
+        column: 1
+
+
+
   SixPack:
     module: pyefis.screens.sixpack
     title: Standard Instrument Panel
@@ -186,10 +202,15 @@ screens:
       type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
       rows: 2
       columns: 3
-    insturments:
+      margin:
+        top: 10
+        left: 10
+        right: 10
+        bottom: 10
+    instruments:
       # Add code, if db_items is missing select from default
       # Add mapping feature
-      # Some insturments need multiple inputs, how would one know what values/mapping is needed?
+      # Some instruments need multiple inputs, how would one know what values/mapping is needed?
       # span
       #  rows: 2
       #  columns: 3

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -15,7 +15,7 @@ main:
   screenColor: (0,0,0)
 
   # If left out the first defined screen will be default
-  defaultScreen: SixPack
+  defaultScreen: SixPackNew
 
 menu:
   menus:
@@ -178,6 +178,10 @@ screens:
   SixPack:
     module: pyefis.screens.sixpack
     title: Standard Instrument Panel
+
+  SixPackNew:
+    module: pyefis.screens.screenbuilder
+    title: Standard Instrument Panel
     layout:
       type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
       rows: 2
@@ -186,6 +190,9 @@ screens:
       # Add code, if db_items is missing select from default
       # Add mapping feature
       # Some insturments need multiple inputs, how would one know what values/mapping is needed?
+      # span
+      #  rows: 2
+      #  columns: 3
       -
         type: airspeed_dial
         db_items: IAS
@@ -211,6 +218,18 @@ screens:
           - ALAT
         row: 2
         column: 1
+      - 
+        type: horizontal_situation_indicator
+        db_items:
+          - COURSE
+          - CDI
+          - GSI
+          - HEAD
+        row: 2
+        column: 2
+        options:
+          gsi_enabled: true
+          cdi_enabled: true
       -
         type: vsi_dial
         db_items: VS

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -5,8 +5,10 @@ main:
   # Screen Geometry
   #screenWidth: 1024
   #screenHeight: 768
-  screenWidth: 800
-  screenHeight: 480
+  screenWidth: 1920
+  screenHeight: 1080
+  #screenWidth: 800
+  #screenHeight: 480
   #screenWidth: 3840
   #screenHeight: 1100
   # Set EFIS to occupy the entire screen without system border / menu
@@ -16,7 +18,7 @@ main:
   screenColor: (0,0,0)
 
   # If left out the first defined screen will be default
-  defaultScreen: EMSNew #EMSNew
+  defaultScreen: MainScreen
 
 menu:
   menus:
@@ -157,6 +159,161 @@ outputs:
 # the screen
 
 screens:
+  MainScreen:
+    module: pyefis.screens.screenbuilder
+    title: Engine Management
+    layout:
+      type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
+      rows: 110
+      columns: 303
+    instruments:
+      - type: atitude_indicator
+        row: 1
+        column: 1
+        span:
+          rows: 110
+          columns: 120
+      - type: altimeter_tape
+        db_item: ALT
+        row: 1
+        column: 105
+        span:
+          rows: 110
+          columns: 15
+        options:
+          fontsize: 22
+      - type: ganged_arc_gauge
+        gang_type: vertical
+        row: 1
+        column: 121
+        span:
+          rows: 110
+          columns: 60
+        groups:
+          - name: Engine
+            instruments:
+              -
+                db_item: TACH1
+                options:
+                  name: RPM
+                  decPlaces: 0
+              -
+                db_item: CHTMAX1
+                options:
+                  name: Max CHT
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: EGTAVG1
+                options:
+                  name: Avg EGT
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: H2OT1
+                options:
+                  name: Coolant
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: OILP1
+                options:
+                  name: Oil Press
+                  decPlaces: 1
+              -
+                db_item: OILT1
+                options:
+                  name: Oil Temp
+                  decPlaces: 1
+      - type: ganged_arc_gauge
+        gang_type: vertical
+        row: 1
+        column: 182
+        span:
+          rows: 110
+          columns: 60
+        groups:
+          - name: Engine
+            instruments:
+              -
+                db_item: TACH1
+                options:
+                  name: Fuel Total
+                  decPlaces: 0
+              -
+                db_item: CHTMAX1
+                options:
+                  name: Fuel Left
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: EGTAVG1
+                options:
+                  name: Fuel Center
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: H2OT1
+                options:
+                  name: Fuel Right
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: OILP1
+                options:
+                  name: 
+                  decPlaces: 1
+              -
+                db_item: OILT1
+                options:
+                  name: Fuel Range
+                  decPlaces: 1
+      - type: ganged_arc_gauge
+        gang_type: vertical
+        row: 1
+        column: 243
+        span:
+          rows: 110
+          columns: 60
+        groups:
+          - name: Misc
+            instruments:
+              -
+                db_item: H2OT1
+                options:
+                  name: Battery
+                  decPlaces: 0
+              -
+                db_item: H2OT1
+                options:
+                  name: Amps
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: EGTAVG1
+                options:
+                  name: OAT
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: H2OT1
+                options:
+                  name: Cabin Temp
+                  decPlaces: 0
+                  temperature: true
+              -
+                db_item: OILP1
+                options:
+                  name:  ???
+                  decPlaces: 1
+              -
+                db_item: OILT1
+                options:
+                  name: ????
+                  decPlaces: 1
+
+
+          
   EPFD:
     module: pyefis.screens.epfd
     title: Primary Flight Display
@@ -332,6 +489,124 @@ screens:
   SixPack:
     module: pyefis.screens.sixpack
     title: Standard Instrument Panel
+
+  ScaleTest:
+    module: pyefis.screens.screenbuilder
+    title: Test how well things scale to different sizes
+    layout:
+      type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
+      rows: 3
+      columns: 6
+    instruments:
+      -
+        type: airspeed_dial
+        row: 1
+        column: 1
+      -
+        type: airspeed_dial
+        row: 1
+        column: 2
+        move:
+          shrink: 10
+      -
+        type: airspeed_dial
+        row: 1
+        column: 3
+        move:
+          shrink: 20
+      -
+        type: airspeed_dial
+        row: 1
+        column: 4
+        move:
+          shrink: 30
+      -
+        type: airspeed_dial
+        row: 1
+        column: 5
+        move:
+          shrink: 40
+      -
+        type: airspeed_dial
+        row: 1
+        column: 6
+        move:
+          shrink: 50
+      - 
+        type: arc_gauge
+        db_item: IAS
+        row: 2
+        column: 1
+      - 
+        type: arc_gauge
+        db_item: IAS
+        row: 2
+        column: 2
+        move:
+          shrink: 10
+      - 
+        type: arc_gauge
+        db_item: IAS
+        row: 2
+        column: 3
+        move:
+          shrink: 20
+      - 
+        type: arc_gauge
+        db_item: IAS
+        row: 2
+        column: 4
+        move:
+          shrink: 30
+      - 
+        type: arc_gauge
+        db_item: IAS
+        row: 2
+        column: 5
+        move:
+          shrink: 40
+      - 
+        type: arc_gauge
+        db_item: IAS
+        row: 2
+        column: 6
+        move:
+          shrink: 50
+      -
+        type: altimeter_dial
+        row: 3
+        column: 1
+      -
+        type: altimeter_dial
+        row: 3
+        column: 2
+        move:
+          shrink: 10
+      -
+        type: altimeter_dial
+        row: 3
+        column: 3
+        move:
+          shrink: 20
+      -
+        type: altimeter_dial
+        row: 3
+        column: 4
+        move:
+          shrink: 30
+      -
+        type: altimeter_dial
+        row: 3
+        column: 5
+        move:
+          shrink: 40
+      -
+        type: altimeter_dial
+        row: 3
+        column: 6
+        move:
+          shrink: 50
+
 
   SixPackNew:
     module: pyefis.screens.screenbuilder

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -255,7 +255,20 @@ screens:
           decPlaces: 1
           showUnits: false
 
-
+      -
+        type: egt_vertical_bar_gauge
+        db_item: EGT
+        row: 8
+        column: 5
+        span:
+          rows: 5
+          columns: 7
+        options:
+          name: EGTs
+          decPlaces: 0
+          showUnits: false
+          cylinders: 4
+          engine: 1
   SixPack:
     module: pyefis.screens.sixpack
     title: Standard Instrument Panel

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -185,7 +185,6 @@ screens:
     instruments:
       -
         type: arc_gauge
-        db_items: TACH1
         row: 1
         column: 1
 
@@ -208,7 +207,6 @@ screens:
         right: 10
         bottom: 10
     instruments:
-      # Add code, if db_items is missing select from default
       # Add mapping feature
       # Some instruments need multiple inputs, how would one know what values/mapping is needed?
       # span
@@ -216,36 +214,21 @@ screens:
       #  columns: 3
       -
         type: airspeed_dial
-        db_items: IAS
         row: 1
         column: 1
       - type: atitude_indicator
-        db_items:
-          - PITCH
-          - ROLL
-          - ALAT
-          - TAS
         row: 1
         column: 2
       -
         type: altimeter_dial
-        db_items: ALT
         row: 1
         column: 3
       -
         type: turn_coordinator
-        db_items:
-          - ROT
-          - ALAT
         row: 2
         column: 1
       - 
         type: horizontal_situation_indicator
-        db_items:
-          - COURSE
-          - CDI
-          - GSI
-          - HEAD
         row: 2             # Row where this grid starts vertical, 1 is top
         column: 2          # Column where this grid starts horizontal, 1 is left
                            # Span is not yet implemented
@@ -271,7 +254,6 @@ screens:
           cdi_enabled: true
       -
         type: heading_display
-        db_items: HEAD
         column: 2
         row: 2
         move:
@@ -281,7 +263,6 @@ screens:
 
       -
         type: vsi_dial
-        db_items: VS
         row: 2
         column: 3
   PFDSM:

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -225,11 +225,39 @@ screens:
           - CDI
           - GSI
           - HEAD
-        row: 2
-        column: 2
+        row: 2             # Row where this grid starts vertical, 1 is top
+        column: 2          # Column where this grid starts horizontal, 1 is left
+                           # Span is not yet implemented
+        #span:             # Defines if this grid should span multiple columns or rows making it larger
+          #rows: 2         # This grid will occupuy row 2 and 3, 2 rows
+          #columns: 2      # This grid will occupy columns 2 and 3, 2 columns
+        move:              # Everything maintains aspect ratio of the grid you defined, 
+                           # with row, column and span but you can make things smaller by percentages
+                           # The default is for the object to occupy the whole space
+          shrink: 21       # This will reduce the size by 10 percent
+                           # When shrinking the default is for the object to be centered horizontal and vertically
+          justify:         # If you want to move it you can use 'top', 'bottom', 'left' or 'right'
+            - bottom       # If you decide to configure top and bottom or right and left
+                           # Only one of the mutually exclusive options will be used
+                           # While this might seem limiting, keep in mind that you can make a high number of initial grids
+                           # Then use span along with shrink and justify to get items precisely placed.
+                           # Hopefully one day all the widgets will be updated to scale fonts and such based on the size of the space they occupy
+                           # This would make it very simple to resize, just change the size of the window and all items will be proportionally 
+                           # moved and sized to fit. If you go wider gauges might have more space between them horizontally
+                           # However, the screen would still be usable without having to change any other setting.
         options:
           gsi_enabled: true
           cdi_enabled: true
+      -
+        type: heading_display
+        db_items: HEAD
+        column: 2
+        row: 2
+        move:
+          shrink: 80
+          justify:
+            - top
+
       -
         type: vsi_dial
         db_items: VS

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -15,7 +15,7 @@ main:
   screenColor: (0,0,0)
 
   # If left out the first defined screen will be default
-  defaultScreen: SixPackNew
+  defaultScreen: EMSNew #EMSNew
 
 menu:
   menus:
@@ -39,7 +39,7 @@ menu:
           - ['Show', 'activate menu','PFDMenu']
       ShowMenu2:
           - ['Show', 'activate menu','BasicMenu']
-  start_menu: ShowMenu
+  start_menu: PFDMenu
 #  show_time: 3  # hides the menu after 3 seconds.  However cannot show again.  Don't use.  Here for reference only.
   number_of_buttons: 6
   buttons_spacing: 120
@@ -180,14 +180,80 @@ screens:
     title: Engine Management
     layout:
       type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
-      rows: 800
-      columns: 640
+      rows: 16
+      columns: 27
     instruments:
       -
         type: arc_gauge
+        db_item: TACH1
         row: 1
         column: 1
+        span:
+          rows: 4
+          columns: 10
+        options:
+          name: RPM
+          decimalPlaces: 0
+      -
+        type: arc_gauge
+        db_item: MAP1
+        row: 1
+        column: 11
+        span:
+          rows: 4
+          columns: 10
+        options:
+          name: MAP
+          decimalPlaces: 1          
+      -
+        type: horizontal_bar_gauge
+        db_item: OILP1
+        row: 1
+        column: 21
+        span:
+          rows: 3
+          columns: 7
+        options:
+          name: Oil Press
+          decPlaces: 1
+          temperature: true
+          
+      -
+        type: horizontal_bar_gauge
+        db_item: OILT1
+        row: 4
+        column: 21
+        span:
+          rows: 3
+          columns: 7
+        options:
+          name: Oil Temp
+          decPlaces: 1
 
+      -
+        type: vertical_bar_gauge
+        db_item: VOLT
+        row: 8
+        column: 1
+        span:
+          rows: 5
+          columns: 2
+        options:
+          name: Volt
+          decPlaces: 1
+          showUnits: false
+      -
+        type: vertical_bar_gauge
+        db_item: CURRNT
+        row: 8
+        column: 3
+        span:
+          rows: 5
+          columns: 2
+        options:
+          name: Amp
+          decPlaces: 1
+          showUnits: false
 
 
   SixPack:

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -18,7 +18,7 @@ main:
   screenColor: (0,0,0)
 
   # If left out the first defined screen will be default
-  defaultScreen: MainScreen
+  defaultScreen: PFD #MainScreen
 
 menu:
   menus:
@@ -160,37 +160,60 @@ outputs:
 
 screens:
   MainScreen:
+    dbpath: /home/eblevins/projects/efis/CIFP/FAACIFP18
+    indexpath: /home/eblevins/projects/efis/CIFP/index.bin
     module: pyefis.screens.screenbuilder
-    title: Engine Management
+    title: Screen Builder
     layout:
       type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
       rows: 110
-      columns: 303
+      columns: 384
     instruments:
-      - type: atitude_indicator
+#      - type: atitude_indicator
+      - type: virtual_vfr
         row: 1
-        column: 1
+        column: 50
         span:
           rows: 110
-          columns: 120
+          columns: 150
       - type: altimeter_tape
         db_item: ALT
         row: 1
-        column: 105
+        column: 185
         span:
           rows: 110
           columns: 15
         options:
           fontsize: 22
+      - type: airspeed_tape
+        db_item: IAS
+        row: 1
+        column: 50
+        span:
+          rows: 110
+          columns: 15
+        options:
+          fontsize: 22
+      - type: heading_tape
+        db_item: IAS
+        row: 100
+        column: 50
+        span:
+          rows: 11
+          columns: 150
+        options:
+          fontsize: 25
       - type: ganged_arc_gauge
         gang_type: vertical
         row: 1
-        column: 121
+        column: 201
         span:
           rows: 110
-          columns: 60
+          columns: 40
         groups:
           - name: Engine
+            common_options:
+              nameLocation: right
             instruments:
               -
                 db_item: TACH1
@@ -228,105 +251,109 @@ screens:
       - type: ganged_arc_gauge
         gang_type: vertical
         row: 1
-        column: 182
+        column: 242
         span:
           rows: 110
-          columns: 60
+          columns: 40
         groups:
           - name: Engine
+            common_options:
+              nameLocation: right
             instruments:
               -
-                db_item: TACH1
+                db_item: FUELQT
                 options:
                   name: Fuel Total
                   decPlaces: 0
               -
-                db_item: CHTMAX1
+                db_item: FUELQ1
                 options:
                   name: Fuel Left
                   decPlaces: 0
                   temperature: true
               -
-                db_item: EGTAVG1
+                db_item: FUELQ2
                 options:
                   name: Fuel Center
                   decPlaces: 0
                   temperature: true
               -
-                db_item: H2OT1
+                db_item: FUELQ3
                 options:
                   name: Fuel Right
                   decPlaces: 0
                   temperature: true
               -
-                db_item: OILP1
+                db_item: FUELF1
                 options:
-                  name: 
+                  name: Fuel Flow
                   decPlaces: 1
               -
-                db_item: OILT1
+                db_item: FUELP1
                 options:
-                  name: Fuel Range
+                  name: Fuel Pressure
                   decPlaces: 1
       - type: ganged_arc_gauge
         gang_type: vertical
         row: 1
-        column: 243
+        column: 283
         span:
           rows: 110
-          columns: 60
+          columns: 40
         groups:
           - name: Misc
+            common_options:
+              nameLocation: right
             instruments:
               -
-                db_item: H2OT1
+                db_item: VOLT
                 options:
                   name: Battery
                   decPlaces: 0
               -
-                db_item: H2OT1
+                db_item: CURRNT
                 options:
                   name: Amps
                   decPlaces: 0
                   temperature: true
               -
-                db_item: EGTAVG1
+                db_item: OAT
                 options:
                   name: OAT
                   decPlaces: 0
                   temperature: true
               -
-                db_item: H2OT1
+                db_item: CAT
                 options:
                   name: Cabin Temp
                   decPlaces: 0
                   temperature: true
               -
-                db_item: OILP1
+                db_item: BARO
                 options:
-                  name:  ???
+                  name:  Baro set
                   decPlaces: 1
               -
-                db_item: OILT1
+                db_item: THR1
                 options:
-                  name: ????
+                  name: Throttle
                   decPlaces: 1
 
 
           
   EPFD:
     module: pyefis.screens.epfd
-    title: Primary Flight Display
-    dbpath: /home/phil/.makerplane/data/CIFP/FAACIFP18
-    indexpath: /home/phil/.makerplane/data/CIFP/index.bin
+    title: E Primary Flight Display
+    dbpath: /home/eblevins/projects/efis/CIFP/FAACIFP18
+    indexpath: /home/eblevins/projects/efis/CIFP/index.bin
     check_engine: [MAP1, TACH1, OILP1, OILT1, FUELQT, FUELF1, CHTMAX1, EGTAVG1]
     update_period: .1
 
   PFD:
     module: pyefis.screens.pfd
     title: Primary Flight Display
-    dbpath: /home/phil/.makerplane/data/CIFP/FAACIFP18
-    indexpath: /home/phil/.makerplane/data/CIFP/index.bin
+    dbpath: /home/eblevins/projects/efis/CIFP/FAACIFP18
+    indexpath: /home/eblevins/projects/efis/CIFP/index.bin
     update_period: .1
 
   EMS:
@@ -335,7 +362,7 @@ screens:
 
   EMSNew:
     module: pyefis.screens.screenbuilder
-    title: Engine Management
+    title: Engine Management New
     layout:
       type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
       rows: 16
@@ -533,41 +560,35 @@ screens:
         move:
           shrink: 50
       - 
-        type: arc_gauge
-        db_item: IAS
+        type: atitude_indicator
         row: 2
         column: 1
       - 
-        type: arc_gauge
-        db_item: IAS
+        type: atitude_indicator
         row: 2
         column: 2
         move:
           shrink: 10
       - 
-        type: arc_gauge
-        db_item: IAS
+        type: atitude_indicator
         row: 2
         column: 3
         move:
           shrink: 20
       - 
-        type: arc_gauge
-        db_item: IAS
+        type: atitude_indicator
         row: 2
         column: 4
         move:
           shrink: 30
       - 
-        type: arc_gauge
-        db_item: IAS
+        type: atitude_indicator
         row: 2
         column: 5
         move:
           shrink: 40
       - 
-        type: arc_gauge
-        db_item: IAS
+        type: atitude_indicator
         row: 2
         column: 6
         move:
@@ -610,7 +631,7 @@ screens:
 
   SixPackNew:
     module: pyefis.screens.screenbuilder
-    title: Standard Instrument Panel
+    title: Standard Instrument Panel New
     layout:
       type: grid #Splits the screen into evenly sized grids where each grid can contain a single insturment
       rows: 2

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -205,6 +205,13 @@ screens:
         row: 1
         column: 3
       -
+        type: turn_coordinator
+        db_items:
+          - ROT
+          - ALAT
+        row: 2
+        column: 1
+      -
         type: vsi_dial
         db_items: VS
         row: 2

--- a/pyefis/config/main.yaml
+++ b/pyefis/config/main.yaml
@@ -183,6 +183,14 @@ screens:
       rows: 2
       columns: 3
     insturments:
+      # Add code, if db_items is missing select from default
+      # Add mapping feature
+      # Some insturments need multiple inputs, how would one know what values/mapping is needed?
+      -
+        type: airspeed_dial
+        db_items: IAS
+        row: 1
+        column: 1
       -
         type: altimeter_dial
         db_items: ALT

--- a/pyefis/instruments/NumericalDisplay/__init__.py
+++ b/pyefis/instruments/NumericalDisplay/__init__.py
@@ -36,6 +36,8 @@ class NumericalDisplay(QGraphicsView):
         self._bad = False
         self._old = False
         self._fail = False
+        # Ensure all vars are init so paint events do not cause crash 
+        self.resizeEvent(None)
 
     def resizeEvent(self, event):
         self.w = self.width()

--- a/pyefis/instruments/NumericalDisplay/__init__.py
+++ b/pyefis/instruments/NumericalDisplay/__init__.py
@@ -152,7 +152,7 @@ class NumericalDisplay(QGraphicsView):
 
     def getBad(self):
         return self._bad
-    def setBad(self, b):
+    def setBad(self, b,item=None):
         if self._bad != b:
             self._bad = b
             #if b:

--- a/pyefis/instruments/ai/VirtualVfr.py
+++ b/pyefis/instruments/ai/VirtualVfr.py
@@ -53,28 +53,62 @@ class VirtualVfr(AI):
     PAPI_YOFFSET = 8
     PAPI_LIGHT_SPACING = 9
     VORTAC_ICON_PATH="vortac.png"
-    def __init__(self, parent=None):
-        super(VirtualVfr, self).__init__(parent)
+    def __init__(self, parent=None, data=None):
+        super(VirtualVfr, self).__init__(parent,data=data)
         self.display_objects = dict()
-        time.sleep(.4)      # Pause to let DB load
-        self.lng_item = fix.db.get_item("LONG")
-        self.lat_item = fix.db.get_item("LAT")
-        self.head_item = fix.db.get_item("HEAD")
-        self.alt_item = fix.db.get_item("ALT")
+        time.sleep(.5)      # Pause to let DB load
+
+        self._VFROld = dict()
+        self._VFRBad = dict()
+        self._VFRFail = dict()
+        for p in ['LAT', 'HEAD', 'ALT', 'LONG']:
+            self._VFROld[p] = True
+            self._VFRBad[p] = True
+            self._VFRFail[p] = True
+        self.init_fix = False
+        if data:
+            self.lng = data["LONG"]
+            self.lat = data["LAT"]
+            self.head = data["HEAD"]
+            self.altitude = data["ALT"]
+            # BUG: convert magnetic heading
+            self.true_heading = data["HEAD"]
+
+        else:
+            self.init_fix = True
+            self.lng_item = fix.db.get_item("LONG")
+            self.lat_item = fix.db.get_item("LAT")
+            self.head_item = fix.db.get_item("HEAD")
+            self.alt_item = fix.db.get_item("ALT")
+
+            self._VFROld['LONG'] = self.lng_item.old
+            self._VFRBad['LONG'] = self.lng_item.bad
+            self._VFRFail['LONG'] = self.lng_item.fail
+            self.lng = self.lng_item.value
+
+            self._VFROld['LAT'] = self.lat_item.old
+            self._VFRBad['LAT'] = self.lat_item.bad
+            self._VFRFail['LAT'] = self.lat_item.fail
+            self.lat = self.lat_item.value
+
+            self._VFROld['HEAD'] = self.head_item.old
+            self._VFRBad['HEAD'] = self.head_item.bad
+            self._VFRFail['HEAD'] = self.head_item.fail
+            self.head = self.head_item.value
+            # BUG: convert magnetic heading
+            self.true_heading = self.head_item.value
+
+            self._VFROld['ALT'] = self.alt_item.old
+            self._VFRBad['ALT'] = self.alt_item.bad
+            self._VFRFail['ALT'] = self.alt_item.fail
+            self.altitude = self.alt_item.value
+
+
         self.last_mag_update = 0
         self.magnetic_declination = None
         self.missing_lat = True
         self.missing_lng = True
-        self.lat = self.lat_item.value
-        self.lng = self.lng_item.value
-        self.altitude = self.alt_item.value
-        self.rendering_prohibited = \
-            self.lng_item.fail or self.lng_item.bad or self.lng_item.old or \
-            self.lat_item.fail or self.lat_item.bad or self.lat_item.old or \
-            self.head_item.fail or self.head_item.bad or self.head_item.old or \
-            self.alt_item.fail or self.alt_item.bad or self.alt_item.old
-        # BUG: convert magnetic heading
-        self.true_heading = self.head_item.value
+
         self.myparent = parent
         minfont = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, VirtualVfr.MIN_FONT_SIZE, QFont.Bold)
         t = QGraphicsSimpleTextItem ("9 9")
@@ -89,23 +123,26 @@ class VirtualVfr(AI):
                                self.myparent.get_config_item('refresh_period'))
         self.pov.initialize(["Runway", "Airport"], self.scene.width(),
                     self.lng, self.lat, self.altitude, self.true_heading)
-        self.lng_item.valueChanged[float].connect(self.setLongitude)
-        self.lng_item.badChanged[bool].connect(self.setBlank)
-        self.lng_item.oldChanged[bool].connect(self.setBlank)
-        self.lng_item.failChanged[bool].connect(self.setBlank)
-        self.lat_item.valueChanged[float].connect(self.setLatitude)
-        self.lat_item.badChanged[bool].connect(self.setBlank)
-        self.lat_item.oldChanged[bool].connect(self.setBlank)
-        self.lat_item.failChanged[bool].connect(self.setBlank)
-        self.head_item.valueChanged[float].connect(self.setHeading)
-        self.head_item.badChanged[bool].connect(self.setBlank)
-        self.head_item.oldChanged[bool].connect(self.setBlank)
-        self.head_item.failChanged[bool].connect(self.setBlank)
-        self.alt_item.valueChanged[float].connect(self.setAltitude)
-        self.alt_item.badChanged[bool].connect(self.setBlank)
-        self.alt_item.oldChanged[bool].connect(self.setBlank)
-        self.alt_item.failChanged[bool].connect(self.setBlank)
-        if not self.rendering_prohibited:
+        if self.init_fix:
+            # Must happen here to prevent race
+            self.lng_item.valueChanged[float].connect(self.setLongitude)
+            self.lng_item.badChanged[bool].connect(self.setLngBad)
+            self.lng_item.oldChanged[bool].connect(self.setLngOld)
+            self.lng_item.failChanged[bool].connect(self.setLngFail)
+            self.lat_item.valueChanged[float].connect(self.setLatitude)
+            self.lat_item.badChanged[bool].connect(self.setLatBad)
+            self.lat_item.oldChanged[bool].connect(self.setLatOld)
+            self.lat_item.failChanged[bool].connect(self.setLatFail)
+            self.head_item.valueChanged[float].connect(self.setHeading)
+            self.head_item.badChanged[bool].connect(self.setHeadBad)
+            self.head_item.oldChanged[bool].connect(self.setHeadOld)
+            self.head_item.failChanged[bool].connect(self.setHeadFail)
+            self.alt_item.valueChanged[float].connect(self.setAltitude)
+            self.alt_item.badChanged[bool].connect(self.setAltBad)
+            self.alt_item.oldChanged[bool].connect(self.setAltOld)
+            self.alt_item.failChanged[bool].connect(self.setAltFail)
+
+        if not self.rendering_prohibited():
             self.pov.render(self)
 
     def get_largest_font_size(self, width):
@@ -115,7 +152,7 @@ class VirtualVfr(AI):
         ret = (max_size - min_size) / 2
         t = QGraphicsSimpleTextItem ("9 9")
         while True:
-            font = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, ret, QFont.Bold)
+            font = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, qRound(ret), QFont.Bold)
             t.setFont (font)
             if t.boundingRect().width() * 1.5 > width:
                 max_size = ret
@@ -128,7 +165,7 @@ class VirtualVfr(AI):
         incr = int((max_size - min_size) / 2)
         while incr > 0:
             ret += incr
-            font = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, ret, QFont.Bold)
+            font = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, qRound(ret), QFont.Bold)
             t.setFont (font)
             if t.boundingRect().width() * 1.1 > width:
                 ret -= incr
@@ -175,12 +212,12 @@ class VirtualVfr(AI):
         key = name+airport_id
         if key in self.display_objects:
             # print ("update existing runway polygon %s"%key)
-            poly = QPolygonF([QPoint(*p11), QPoint(*p12), QPoint(*p21), QPoint(*p22)])
+            poly = QPolygonF([QPointF(*p11), QPointF(*p12), QPointF(*p21), QPointF(*p22)])
             rw = self.display_objects[key]
             rw.setPolygon(poly)
         else:
             # print ("make new runway polygon %s"%key)
-            poly = QPolygonF([QPoint(*p11), QPoint(*p12), QPoint(*p21), QPoint(*p22)])
+            poly = QPolygonF([QPointF(*p11), QPointF(*p12), QPointF(*p21), QPointF(*p22)])
             pen = QPen(QColor(Qt.white))
             brush = QBrush(QColor(Qt.black))
             if label[-1] == "W":
@@ -217,7 +254,7 @@ class VirtualVfr(AI):
             clpoints[bottomi] = (F(bottomy, cline_function), bottomy)
             topy = clpoints[topi][1]+2*VirtualVfr.CENTERLINE_WIDTH
             clpoints[topi] = (F(topy, cline_function), topy)
-            cline = QLineF(QPoint(*clpoints[0]), QPoint(*clpoints[1]))
+            cline = QLineF(QPointF(*clpoints[0]), QPointF(*clpoints[1]))
             if clkey in self.display_objects:
                  centerline = self.display_objects[clkey]
                  centerline.setLine(cline)
@@ -235,7 +272,7 @@ class VirtualVfr(AI):
             if draw_width > self.min_font_width*1.5:
                 #print ("Runway label will fit underneath runway polygon. font size is %d"%font_size)
                 font_size = self.get_largest_font_size(draw_width)
-                font = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, font_size, QFont.Bold)
+                font = QFont(VirtualVfr.RUNWAY_LABEL_FONT_FAMILY, qRound(font_size), QFont.Bold)
                 label = label[0] + " " + label[1:]
                 if lkey in self.display_objects:
                     # Update label position
@@ -279,8 +316,8 @@ class VirtualVfr(AI):
             if clpoints[0][1] > clpoints[1][1]:
                 touchdown_point = QPoint (*clpoints[0])
             else:
-                touchdown_point = QPoint (*clpoints[1])
-            extended_point = QPoint(bottom_intercept, self.scene.height()/2)
+                touchdown_point = QPointF (*clpoints[1])
+            extended_point = QPointF(bottom_intercept, self.scene.height()/2)
             eline = QLineF(touchdown_point, extended_point)
             if elkey in self.display_objects:
                  extendedline = self.display_objects[elkey]
@@ -449,7 +486,7 @@ class VirtualVfr(AI):
         self.missing_lat = False
         #print ("New latitude %f"%self.lat)
         self.pov.update_position (self.lat, self.lng)
-        if not self.rendering_prohibited:
+        if not self.rendering_prohibited():
             self.pov.render(self)
 
     def setLongitude(self, lng):
@@ -457,7 +494,7 @@ class VirtualVfr(AI):
         self.missing_lng = False
         #print ("New longitude %f"%self.lng)
         self.pov.update_position (self.lat, self.lng)
-        if not self.rendering_prohibited:
+        if not self.rendering_prohibited():
             self.pov.render(self)
 
     def setAltitude(self, alt):
@@ -475,18 +512,144 @@ class VirtualVfr(AI):
         if md is None:
             md = 0
         self.pov.update_heading (heading + md)
-        if not self.rendering_prohibited:
+        if not self.rendering_prohibited():
             self.pov.render(self)
 
+    def setData(self,item,value):
+        print(f"setData {item} {value}")
+        if item == 'HEAD':
+            self.setHeading(value)
+        elif item == 'ALT':
+            self.setAltitude(value)
+        elif item == 'LAT':
+            self.setLatitude(value)
+        elif item == 'LONG':
+            self.setLongitude(value)
+        elif item == 'PITCH':
+            self.setPitchAngle(value)
+        elif item == 'ROLL':
+            self.setRollAngle(value)
+        elif item == 'ALAT':
+            self.setLateralAcceleration(value)
+        elif item == 'TAS':
+            self.setTrueAirspeed(value)
+
+    def getBad(self):
+        print(self._VFRBad)
+        return True in self._VFRBad.values()
+
+    def setBad(self, bad, item=None):
+        self._VFRBad[item] = bad
+        self.setBlank(bad)
+        if item in self._AIBad and bad != self._AIBad[item]:
+            self._AIBad[item] = bad
+            if hasattr(self, 'sky_rect'):
+                if self.getAIBad():
+                    self.sky_rect.setBrush (self.gray_sky)
+                    self.land_rect.setBrush (self.gray_land)
+                    #self.bad_text.show()
+                else:
+                    self.sky_rect.setBrush (self.gblue_brush)
+                    self.land_rect.setBrush (self.gbrown_brush)
+                    #self.bad_text.hide()
+                self.redraw()
+
+    def setLngBad(self,bad):
+        self.setBad(bad,'LONG')
+
+    def setLatBad(self,bad):
+        self.setBad(bad,'LAT')
+
+    def setHeadBad(self,bad):
+        self.setBad(bad,'HEAD')
+
+    def setAltBad(self,bad):
+        self.setBad(bad,'ALT')
+
+
+    def getOld(self):
+        print(f"VFR getOld {self._VFROld}")
+        return True in self._VFROld.values()
+
+    def setOld(self, old, item=None):
+        print(f"VFR setOld {self._VFROld}")
+        self._VFROld[item] = old
+        self.setBlank(old)
+        if item in self._AIOld and old != self._AIOld[item]:
+            self._AIOld[item] = old
+            if hasattr(self, 'sky_rect'):
+                if self.getAIOld():
+                    self.sky_rect.setBrush (self.gray_sky)
+                    self.land_rect.setBrush (self.gray_land)
+                    #self.old_text.show()
+                else:
+                    self.sky_rect.setBrush (self.gblue_brush)
+                    self.land_rect.setBrush (self.gbrown_brush)
+                    #self.old_text.hide()
+                self.redraw()
+    def setLngOld(self,old):
+        print(f"VFR setLngOld {old}")
+        self.setOld(old,'LONG')
+
+    def setLatOld(self,old):
+        self.setOld(old,'LAT')
+
+    def setHeadOld(self,old):
+        self.setOld(old,'HEAD')
+
+    def setAltOld(self,old):
+        self.setOld(old,'ALT')
+
+    def getFail(self):
+        #print(self._VFRFail)
+        return True in self._VFRFail.values()
+
+    def setFail(self, fail, item=None):
+        self._VFRFail[item] = fail
+        self.setBlank(fail)
+        if item in self._AIFail and fail != self._AIFail[item]:
+            self._AIFail[item] = fail
+            if hasattr(self, 'fail_scene'):
+                if self.getAIFail():
+                    self.resetTransform()
+                    self.setScene (self.fail_scene)
+                else:
+                    self.setScene (self.scene)
+                    # Initially set to grey
+                    # we may have old data while recovering
+                    if hasattr(self, 'sky_rect'):
+                        if self.getAIFail():
+                            self.sky_rect.setBrush (self.gray_sky)
+                            self.land_rect.setBrush (self.gray_land)
+                        else:
+                            self.sky_rect.setBrush (self.gblue_brush)
+                            self.land_rect.setBrush (self.gbrown_brush)
+                self.redraw()
+
+    def setLngFail(self,fail):
+        self.setFail(fail,'LONG')
+
+    def setLatFail(self,fail):
+        self.setFail(fail,'LAT')
+
+    def setHeadFail(self,fail):
+        self.setFail(fail,'HEAD')
+
+    def setAltFail(self,fail):
+        self.setFail(fail,'ALT')
+
+    def rendering_prohibited(self):
+        return self.getFail() or self.getBad() or self.getOld()
+
     def setBlank(self, b):
-        self.rendering_prohibited = \
-            self.lng_item.fail or self.lng_item.bad or self.lng_item.old or \
-            self.lat_item.fail or self.lat_item.bad or self.lat_item.old or \
-            self.head_item.fail or self.head_item.bad or self.head_item.old or \
-            self.alt_item.fail or self.alt_item.bad or self.alt_item.old
-        if self.rendering_prohibited and len(self.display_objects) > 0:
+        if self.rendering_prohibited() and len(self.display_objects) > 0:
             for key in self.display_objects.keys():
-                self.scene.removeItem(self.display_objects[key])
+                # The lights seem to be stored in a list 
+                if isinstance(self.display_objects[key],list):
+                    for delobj in self.display_objects[key]:
+                        self.scene.removeItem(delobj)
+                else:
+                    self.scene.removeItem(self.display_objects[key])
             self.display_objects = dict()
 
 VIEWPORT_ANGLE100 = 35.0 / 2.0 * RAD_DEG

--- a/pyefis/instruments/ai/__init__.py
+++ b/pyefis/instruments/ai/__init__.py
@@ -378,8 +378,12 @@ class AI(QGraphicsView):
                     # Initially set to grey
                     # we may have old data while recovering
                     if hasattr(self, 'sky_rect'):
-                        self.sky_rect.setBrush (self.gray_sky)
-                        self.land_rect.setBrush (self.gray_land)
+                        if self._AIOld:
+                            self.sky_rect.setBrush (self.gray_sky)
+                            self.land_rect.setBrush (self.gray_land)
+                        else:
+                            self.sky_rect.setBrush (self.gblue_brush)
+                            self.land_rect.setBrush (self.gbrown_brush)
                     self.redraw()
 
     def setAIOld(self, old):

--- a/pyefis/instruments/ai/__init__.py
+++ b/pyefis/instruments/ai/__init__.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 #   Add configuration for bank angle tick sizes
 
 class AI(QGraphicsView):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None,data=None):
         super(AI, self).__init__(parent)
         self.myparent = parent
 
@@ -68,27 +68,41 @@ class AI(QGraphicsView):
         self.setRenderHint(QPainter.Antialiasing)
         self.setFocusPolicy(Qt.NoFocus)
 
-        pitch = fix.db.get_item("PITCH")
-        pitch.valueChanged[float].connect(self.setPitchAngle)
-        pitch.oldChanged[bool].connect(self.setAIOld)
-        pitch.badChanged[bool].connect(self.setAIBad)
-        pitch.failChanged[bool].connect(self.setAIFail)
-        self._pitchAngle = pitch.value
-        roll = fix.db.get_item("ROLL")
-        roll.valueChanged[float].connect(self.setRollAngle)
-        roll.oldChanged[bool].connect(self.setAIOld)
-        roll.badChanged[bool].connect(self.setAIBad)
-        roll.failChanged[bool].connect(self.setAIFail)
-        self._rollAngle = roll.value
-        self._AIOld = roll.old
-        self._AIBad = roll.bad
-        self._AIFail = roll.fail
-        alat = fix.db.get_item("ALAT")
-        alat.valueChanged[float].connect(self.setLateralAcceleration)
-        self._latAccel = alat.value
-        tas = fix.db.get_item("TAS")
-        tas.valueChanged[float].connect(self.setTrueAirspeed)
-        self._tas = tas.value
+        if data:
+            pitch = data['PITCH']
+            roll = data["ROLL"]
+            alat = data["ALAT"]
+            tas = data["TAS"]
+            self._pitchAngle = pitch.value
+            self._rollAngle = roll.value
+            self._AIOld = roll.old
+            self._AIBad = roll.bad
+            self._AIFail = roll.fail
+            self._latAccel = alat.value
+            self._tas = tas.value
+
+        else:
+            pitch = fix.db.get_item("PITCH")
+            pitch.valueChanged[float].connect(self.setPitchAngle)
+            pitch.oldChanged[bool].connect(self.setAIOld)
+            pitch.badChanged[bool].connect(self.setAIBad)
+            pitch.failChanged[bool].connect(self.setAIFail)
+            self._pitchAngle = pitch.value
+            roll = fix.db.get_item("ROLL")
+            roll.valueChanged[float].connect(self.setRollAngle)
+            roll.oldChanged[bool].connect(self.setAIOld)
+            roll.badChanged[bool].connect(self.setAIBad)
+            roll.failChanged[bool].connect(self.setAIFail)
+            self._rollAngle = roll.value
+            self._AIOld = roll.old
+            self._AIBad = roll.bad
+            self._AIFail = roll.fail
+            alat = fix.db.get_item("ALAT")
+            alat.valueChanged[float].connect(self.setLateralAcceleration)
+            self._latAccel = alat.value
+            tas = fix.db.get_item("TAS")
+            tas.valueChanged[float].connect(self.setTrueAirspeed)
+            self._tas = tas.value
         # We store all the pitch tick marks and text in a list so that
         # we can adjust the opacity of the items.
         self.pitchItems = []

--- a/pyefis/instruments/ai/__init__.py
+++ b/pyefis/instruments/ai/__init__.py
@@ -421,6 +421,16 @@ class AI(QGraphicsView):
     def getPitchAngle(self):
         return self._pitchAngle
 
+    def setData(self,item,value):
+        if item == 'PITCH':
+            self.setPitchAngle(value)
+        elif item == 'ROLL':
+            self.setRollAngle(value)
+        elif item == 'ALAT':
+            self.setLateralAcceleration(value)
+        elif item == 'TAS':
+            self.setTrueAirspeed(value)
+
     pitchAngle = property(getPitchAngle, setPitchAngle)
 
 

--- a/pyefis/instruments/ai/__init__.py
+++ b/pyefis/instruments/ai/__init__.py
@@ -69,30 +69,26 @@ class AI(QGraphicsView):
         self.setFocusPolicy(Qt.NoFocus)
 
         if data:
-            pitch = data['PITCH']
-            roll = data["ROLL"]
-            alat = data["ALAT"]
-            tas = data["TAS"]
-            self._pitchAngle = pitch.value
-            self._rollAngle = roll.value
-            self._AIOld = roll.old
-            self._AIBad = roll.bad
-            self._AIFail = roll.fail
-            self._latAccel = alat.value
-            self._tas = tas.value
-
+            self._pitchAngle = data['PITCH']
+            self._rollAngle = data['ROLL']
+            self._latAccel = data["ALAT"]
+            self._tas = data["TAS"]
+            self._AIOld = True
+            self._AIBad = True
+            self._AIFail = True
         else:
+            # Only place fix is needed for backard compatability
             pitch = fix.db.get_item("PITCH")
             pitch.valueChanged[float].connect(self.setPitchAngle)
-            pitch.oldChanged[bool].connect(self.setAIOld)
-            pitch.badChanged[bool].connect(self.setAIBad)
-            pitch.failChanged[bool].connect(self.setAIFail)
+            pitch.oldChanged[bool].connect(self.setOld)
+            pitch.badChanged[bool].connect(self.setBad)
+            pitch.failChanged[bool].connect(self.setFail)
             self._pitchAngle = pitch.value
             roll = fix.db.get_item("ROLL")
             roll.valueChanged[float].connect(self.setRollAngle)
-            roll.oldChanged[bool].connect(self.setAIOld)
-            roll.badChanged[bool].connect(self.setAIBad)
-            roll.failChanged[bool].connect(self.setAIFail)
+            roll.oldChanged[bool].connect(self.setOld)
+            roll.badChanged[bool].connect(self.setBad)
+            roll.failChanged[bool].connect(self.setFail)
             self._rollAngle = roll.value
             self._AIOld = roll.old
             self._AIBad = roll.bad
@@ -365,7 +361,7 @@ class AI(QGraphicsView):
             self.update()
 
 
-    def setAIFail(self, fail):
+    def setFail(self, fail):
         log.debug("Set AI Fail")
         if fail != self._AIFail:
             self._AIFail = fail
@@ -386,7 +382,7 @@ class AI(QGraphicsView):
                             self.land_rect.setBrush (self.gbrown_brush)
                     self.redraw()
 
-    def setAIOld(self, old):
+    def setOld(self, old):
         log.debug("Set AI Old")
         if old != self._AIOld:
             self._AIOld = old
@@ -401,7 +397,7 @@ class AI(QGraphicsView):
                     #self.old_text.hide()
                     self.redraw()
 
-    def setAIBad(self, bad):
+    def setBad(self, bad):
         log.debug("Set AI Bad")
         if bad != self._AIBad:
             self._AIBad = bad
@@ -434,7 +430,7 @@ class AI(QGraphicsView):
             self.setLateralAcceleration(value)
         elif item == 'TAS':
             self.setTrueAirspeed(value)
-
+        print(f"Set {item} to {value}")
     pitchAngle = property(getPitchAngle, setPitchAngle)
 
 

--- a/pyefis/instruments/airspeed/__init__.py
+++ b/pyefis/instruments/airspeed/__init__.py
@@ -42,6 +42,18 @@ class Airspeed(QWidget):
             self.item.badChanged[bool].connect(self.repaint)
             self.item.failChanged[bool].connect(self.repaint)
 
+        # V Speeds
+        self.Vs = self.item.get_aux_value('Vs')
+        if self.Vs is None: self.Vs = 0
+        self.Vs0 = self.item.get_aux_value('Vs0')
+        if self.Vs0 is None: self.Vs0 = 0
+        self.Vno = self.item.get_aux_value('Vno')
+        if self.Vno is None: self.Vno = 0
+        self.Vne = self.item.get_aux_value('Vne')
+        if self.Vne is None: self.Vne = 200
+        self.Vfe = self.item.get_aux_value('Vfe')
+        if self.Vfe is None: self.Vfe = 0
+
 
     def paintEvent(self, event):
         w = self.width()
@@ -76,20 +88,12 @@ class Airspeed(QWidget):
         yellowPen.setWidth(4)
 
         # Dial Setup
-        # V Speeds
-        Vs = self.item.get_aux_value('Vs')
-        Vs0 = self.item.get_aux_value('Vs0')
-        Vno = self.item.get_aux_value('Vno')
-        Vne = self.item.get_aux_value('Vne')
-        #Va = 120
-        Vfe = self.item.get_aux_value('Vfe')
-
         # VSpeed to angle for drawArc
-        Vs0_angle = (-(((Vs0 - 30) * 2.5) + 26) + 90) * 16
-        Vs_angle = (-(((Vs - 30) * 2.5) + 26) + 90) * 16
-        Vfe_angle = (-(((Vfe - 30) * 2.5) + 25) + 90) * 16
-        Vno_angle = (-(((Vno - 30) * 2.5) + 25) + 90) * 16
-        Vne_angle = (-(((Vne - 30) * 2.5) + 25) + 90) * 16
+        Vs0_angle = (-(((self.Vs0 - 30) * 2.5) + 26) + 90) * 16
+        Vs_angle = (-(((self.Vs - 30) * 2.5) + 26) + 90) * 16
+        Vfe_angle = (-(((self.Vfe - 30) * 2.5) + 25) + 90) * 16
+        Vno_angle = (-(((self.Vno - 30) * 2.5) + 25) + 90) * 16
+        Vne_angle = (-(((self.Vne - 30) * 2.5) + 25) + 90) * 16
 
         radius = int(round(min(w,h) * .45))
         diameter = radius*2

--- a/pyefis/instruments/airspeed/__init__.py
+++ b/pyefis/instruments/airspeed/__init__.py
@@ -365,6 +365,9 @@ class Airspeed_Tape(QGraphicsView):
         if airspeed != self._airspeed:
             self._airspeed = airspeed
             self.redraw()
+    def setData(self, item, value):
+            self.setAirspeed(value)
+            #self.resizeEvent(None)
 
     airspeed = property(getAirspeed, setAirspeed)
 

--- a/pyefis/instruments/airspeed/__init__.py
+++ b/pyefis/instruments/airspeed/__init__.py
@@ -190,6 +190,9 @@ class Airspeed(QWidget):
             self._airspeed = airspeed
             self.update()
 
+    def setData(self, item, value):
+            self.setAirspeed(value)
+
     airspeed = property(getAirspeed, setAirspeed)
 
     def setAsOld(self,b):

--- a/pyefis/instruments/altimeter/__init__.py
+++ b/pyefis/instruments/altimeter/__init__.py
@@ -156,6 +156,8 @@ class Altimeter(QWidget):
         if altimeter != self._altimeter:
             self._altimeter = altimeter
             self.update()
+    def setData(self, item, value):
+        self.setAltimeter(value)
 
     altimeter = property(getAltimeter, setAltimeter)
 
@@ -194,6 +196,9 @@ class Altimeter_Tape(QGraphicsView):
         self._altimeter = 0
         self.numerical_display = NumericalDisplay(self, total_decimals=5, scroll_decimal=2)
         self.numerical_display.value = self._altimeter
+
+        # Ensure all vars are init so paint events do not cause crash 
+        self.resizeEvent(None)
 
     def resizeEvent(self, event):
         w = self.width()

--- a/pyefis/instruments/altimeter/__init__.py
+++ b/pyefis/instruments/altimeter/__init__.py
@@ -178,10 +178,11 @@ class Altimeter_Tape(QGraphicsView):
         else:
             self.item = fix.db.get_item("ALT")
             self._altimeter = self.item.value
-            self.item.valueChanged[float].connect(self.setAltimeter)       
-            self.item.oldChanged[bool].connect(self.setAltOld)             
-            self.item.badChanged[bool].connect(self.setAltBad)             
-            self.item.failChanged[bool].connect(self.setAltFail)           
+
+        self.item.valueChanged[float].connect(self.setAltimeter)
+        self.item.oldChanged[bool].connect(self.setAltOld)
+        self.item.badChanged[bool].connect(self.setAltBad)
+        self.item.failChanged[bool].connect(self.setAltFail)
 
         self.backgroundOpacity = 0.3
         self.foregroundOpacity = 0.6
@@ -253,7 +254,7 @@ class Altimeter_Tape(QGraphicsView):
     def redraw(self):
         self.resetTransform()
         self.centerOn(self.scene.width() / 2, self.y_offset(self._altimeter))
-        self.numerical_display.value = self._altimeter
+        #self.numerical_display.value = self._altimeter
 
     #  Index Line that doesn't move to make it easy to read the altimeter.
     def paintEvent(self, event):
@@ -278,7 +279,11 @@ class Altimeter_Tape(QGraphicsView):
     def setAltimeter(self, altimeter):
         if altimeter != self._altimeter:
             self._altimeter = altimeter
+            self.numerical_display.value = altimeter
             self.redraw()
+
+    def setData(self, item, value):
+        self.setAltimeter(value)
 
     altimeter = property(getAltimeter, setAltimeter)
 

--- a/pyefis/instruments/altimeter/__init__.py
+++ b/pyefis/instruments/altimeter/__init__.py
@@ -172,17 +172,16 @@ class Altimeter_Tape(QGraphicsView):
         self.setFocusPolicy(Qt.NoFocus)
         self.fontsize = fontsize
 
-        print("tape init")
         if data:
             self.item=data
         else:
             self.item = fix.db.get_item("ALT")
             self._altimeter = self.item.value
 
-        self.item.valueChanged[float].connect(self.setAltimeter)
-        self.item.oldChanged[bool].connect(self.setAltOld)
-        self.item.badChanged[bool].connect(self.setAltBad)
-        self.item.failChanged[bool].connect(self.setAltFail)
+            self.item.valueChanged[float].connect(self.setAltimeter)
+            self.item.oldChanged[bool].connect(self.setAltOld)
+            self.item.badChanged[bool].connect(self.setAltBad)
+            self.item.failChanged[bool].connect(self.setAltFail)
 
         self.backgroundOpacity = 0.3
         self.foregroundOpacity = 0.6
@@ -194,7 +193,7 @@ class Altimeter_Tape(QGraphicsView):
         self.maxalt = maxalt
         self.myparent = parent
 
-        self._altimeter = 0
+        self._altimeter = self.item.value
         self.numerical_display = NumericalDisplay(self, total_decimals=5, scroll_decimal=2)
         self.numerical_display.value = self._altimeter
 
@@ -254,7 +253,7 @@ class Altimeter_Tape(QGraphicsView):
     def redraw(self):
         self.resetTransform()
         self.centerOn(self.scene.width() / 2, self.y_offset(self._altimeter))
-        #self.numerical_display.value = self._altimeter
+        self.numerical_display.value = self._altimeter
 
     #  Index Line that doesn't move to make it easy to read the altimeter.
     def paintEvent(self, event):

--- a/pyefis/instruments/gauges/abstract.py
+++ b/pyefis/instruments/gauges/abstract.py
@@ -48,9 +48,11 @@ class AbstractGauge(QWidget):
         self.peakMode = False
         self.__unitSwitching = False
         self.unitGroup = ""
-
+        # if data was passed we do not handle the data internally
+        # 
         if data:
-            self.data = data
+            self.item = data
+            self.data = True
         else:
             self.data = False
         # These properties can be modified by the parent
@@ -123,8 +125,9 @@ class AbstractGauge(QWidget):
         if self._value > self.peakValue:
             self.peakValue = self._value
 
-    def setData(self,item,value):
-        self.setValue(value)
+    def setData(self, item, value):
+        self.value = value
+
     value = property(getValue, setValue)
 
     def getValueText(self):
@@ -139,16 +142,14 @@ class AbstractGauge(QWidget):
         return self._dbkey
 
     def setDbkey(self, key):
-        if self.data:
-            item = self.data 
-        else:
-            item = fix.db.get_item(key)
-            item.auxChanged.connect(self.setAuxData)
-            item.reportReceived.connect(self.setupGauge)
-            item.annunciateChanged.connect(self.annunciateFlag)
-            item.oldChanged.connect(self.oldFlag)
-            item.badChanged.connect(self.badFlag)
-            item.failChanged.connect(self.failFlag)
+        if not self.data:
+            self.item = fix.db.get_item(key)
+            self.item.auxChanged.connect(self.setAuxData)
+            self.item.reportReceived.connect(self.setupGauge)
+            self.item.annunciateChanged.connect(self.annunciateFlag)
+            self.item.oldChanged.connect(self.oldFlag)
+            self.item.badChanged.connect(self.badFlag)
+            self.item.failChanged.connect(self.failFlag)
 
         self._dbkey = key
         self.setupGauge()
@@ -169,40 +170,38 @@ class AbstractGauge(QWidget):
     # This should get called when the gauge is created and then again
     # anytime a new report of the db item is recieved from the server
     def setupGauge(self):
-        if self.data:
-            item = self.data
-        else:
-            item = fix.db.get_item(self.dbkey)
+        if not self.data:
+            self.item = fix.db.get_item(self.dbkey)
         # min and max should always be set for FIX Gateway data.
-        if item.min: self.lowRange = self.conversionFunction(item.min)
-        if item.max: self.highRange = self.conversionFunction(item.max)
-        self._units = item.units
+        if self.item.min: self.lowRange = self.conversionFunction(self.item.min)
+        if self.item.max: self.highRange = self.conversionFunction(self.item.max)
+        self._units = self.item.units
         # set the flags
-        self.fail = item.fail
-        self.bad = item.bad
-        self.old = item.old
-        self.annunciate = item.annunciate
+        self.fail = self.item.fail
+        self.bad = self.item.bad
+        self.old = self.item.old
+        self.annunciate = self.item.annunciate
         self.setColors()
         # set the axuliiary data and the value
-        self.setAuxData(item.aux)
-        self.setValue(item.value)
+        self.setAuxData(self.item.aux)
+        self.setValue(self.item.value)
 
+        # TODO We have to redo the valueChanged signals because the
+        # datatype may have changed
         if not self.data:
-            # TODO We have to redo the valueChanged signals because the
-            # datatype may have changed
             try:
-                item.valueChanged[float].disconnect(self.setValue)
+                self.item.valueChanged[float].disconnect(self.setValue)
             except:
                 pass # One will probably fail all the time
             try:
-                item.valueChanged[int].disconnect(self.setValue)
+                self.item.valueChanged[int].disconnect(self.setValue)
             except:
                 pass # One will probably fail all the time
 
-            if item.dtype == float:
-                item.valueChanged[float].connect(self.setValue)
-            elif item.dtype == int:
-                item.valueChanged[int].connect(self.setValue)
+            if self.item.dtype == float:
+                self.item.valueChanged[float].connect(self.setValue)
+            elif self.item.dtype == int:
+                self.item.valueChanged[int].connect(self.setValue)
 
 
     def setAuxData(self, auxdata):
@@ -281,7 +280,8 @@ class AbstractGauge(QWidget):
         self.__currentUnits = 1
         self.unitsOverride = self.unitsOverride1
         self.conversionFunction = self.conversionFunction1
-        hmi.actions.setInstUnits.connect(self.setUnits)
+        if not self.data:
+            hmi.actions.setInstUnits.connect(self.setUnits)
         self.update()
 
     def setUnits(self, args):
@@ -289,7 +289,8 @@ class AbstractGauge(QWidget):
         command = x[1].lower()
         names = x[0].split(',')
         if self.dbkey in names or '*' in names or self.unitGroup in names:
-            item = fix.db.get_item(self.dbkey)
+            if not self.data:
+                self.item = fix.db.get_item(self.dbkey)
             if command == "toggle":
                 if self.__currentUnits == 1:
                     self.unitsOverride = self.unitsOverride2
@@ -299,5 +300,5 @@ class AbstractGauge(QWidget):
                     self.unitsOverride = self.unitsOverride1
                     self.conversionFunction = self.conversionFunction1
                     self.__currentUnits = 1
-            self.setAuxData(item.aux) # Trigger conversion for aux data
-            self.value = item.value # Trigger the conversion for value
+            self.setAuxData(self.item.aux) # Trigger conversion for aux data
+            self.value = self.item.value # Trigger the conversion for value

--- a/pyefis/instruments/gauges/abstract.py
+++ b/pyefis/instruments/gauges/abstract.py
@@ -125,7 +125,6 @@ class AbstractGauge(QWidget):
 
     def setData(self,item,value):
         self.setValue(value)
-        self.setupGauge()
     value = property(getValue, setValue)
 
     def getValueText(self):

--- a/pyefis/instruments/gauges/arc.py
+++ b/pyefis/instruments/gauges/arc.py
@@ -27,6 +27,7 @@ class ArcGauge(AbstractGauge):
         self.setMinimumSize(100, 50)
         self.startAngle = 45
         self.sweepAngle = 180 - 45
+        self.nameLocation = 'top' # can also be 'right' above the value
 
     def get_height(self, width):
         return width/ 2
@@ -143,11 +144,16 @@ class ArcGauge(AbstractGauge):
         pen.setWidth(1)
         p.setPen(pen)
         f = QFont()
+        f.setPixelSize(qRound(self.r_height / 2))
+        y = f.pixelSize()
         f.setPixelSize(qRound(self.r_height / 6))
+        fm = QFontMetrics(f)
+        x = fm.width(self.name)
         p.setFont(f)
-        #opt = QTextOption(Qt.AlignLeft | Qt.AlignBottom)
-        #p.drawText(QPoint(centerX - (r - 40), centerY - (r - 40)), self.name)
-        p.drawText(QPointF(self.tlcx + (self.r_width / 20),self.tlcy + f.pixelSize()), self.name)
+        if self.nameLocation == 'top':
+            p.drawText(QPointF(self.tlcx + (self.r_width / 20),self.tlcy + f.pixelSize()), self.name)
+        elif self.nameLocation == 'right':
+            p.drawText(QPointF( self.lrcx - x, self.lrcy - (y/1.2)  ), self.name)
 
         # Main value text
         path = QPainterPath()

--- a/pyefis/instruments/gauges/arc.py
+++ b/pyefis/instruments/gauges/arc.py
@@ -22,8 +22,8 @@ from PyQt5.QtWidgets import *
 from .abstract import AbstractGauge, drawCircle
 
 class ArcGauge(AbstractGauge):
-    def __init__(self, parent=None):
-        super(ArcGauge, self).__init__(parent)
+    def __init__(self, parent=None, data=None):
+        super(ArcGauge, self).__init__(parent,data)
         self.setMinimumSize(100, 50)
         self.startAngle = 45
         self.sweepAngle = 180 - 45

--- a/pyefis/instruments/gauges/arc.py
+++ b/pyefis/instruments/gauges/arc.py
@@ -28,9 +28,38 @@ class ArcGauge(AbstractGauge):
         self.startAngle = 45
         self.sweepAngle = 180 - 45
 
+    def get_height(self, width):
+        return width/ 2
+
+    def get_width(self, height):
+        return height * 2
+
     def resizeEvent(self, event):
-        self.arcCenter = QPointF(self.width() / 2, self.height())
-        self.arcRadius = self.height() - 10
+        #Properly pick a center and arc that will fit the area defined
+        if self.width() < self.height():
+            self.r_height = self.get_height(self.width())
+            self.r_width = self.width()
+            if self.height() < self.r_height:
+                self.r_height = self.height()
+                self.r_width = self.get_width(self.height()) 
+        else:
+            self.r_width = self.get_width(self.height())
+            self.r_height = self.height()
+            if self.width() < self.r_width:
+                self.r_height = self.get_height(self.width())
+                self.r_width = self.width()
+
+        c_height = ((self.height() - self.r_height)  / 2) + self.r_height
+        self.lrcx = self.width() - ((self.width()  - self.r_width)  / 2) 
+        self.lrcy =  self.height() - ((self.height() - self.r_height)  / 2)
+        self.tlcx = 0 +  ((self.width() - self.r_width)   / 2)
+        self.tlcy = 0 + ((self.height() - self.r_height)  / 2)
+
+
+        self.arcCenter = QPointF(self.width() / 2, c_height )
+            
+        # self.arcCenter = QPointF(self.width() / 2, self.height())            
+        self.arcRadius = self.r_height - 10
 
         # A polygon for the pointer
         self.arrow = QPolygonF()
@@ -114,11 +143,11 @@ class ArcGauge(AbstractGauge):
         pen.setWidth(1)
         p.setPen(pen)
         f = QFont()
-        f.setPixelSize(qRound(self.height() / 6))
+        f.setPixelSize(qRound(self.r_height / 6))
         p.setFont(f)
-        opt = QTextOption(Qt.AlignLeft | Qt.AlignBottom)
+        #opt = QTextOption(Qt.AlignLeft | Qt.AlignBottom)
         #p.drawText(QPoint(centerX - (r - 40), centerY - (r - 40)), self.name)
-        p.drawText(QPointF(self.width() / 20,f.pixelSize()), self.name)
+        p.drawText(QPointF(self.tlcx + (self.r_width / 20),self.tlcy + f.pixelSize()), self.name)
 
         # Main value text
         path = QPainterPath()
@@ -126,8 +155,8 @@ class ArcGauge(AbstractGauge):
         p.setBrush(brush)
         pen.setColor(QColor(Qt.black))
         p.setPen(pen)
-        f.setPixelSize(qRound(self.height() / 2))
+        f.setPixelSize(qRound(self.r_height / 2))
         fm = QFontMetrics(f)
         x = fm.width(self.valueText)
-        path.addText(QPointF( self.width()-x, self.height()-1),f, self.valueText)
+        path.addText(QPointF( self.lrcx - x, self.lrcy - 1),f, self.valueText)
         p.drawPath(path)

--- a/pyefis/instruments/gauges/egt.py
+++ b/pyefis/instruments/gauges/egt.py
@@ -24,15 +24,19 @@ from .abstract import AbstractGauge
 from .verticalBar import VerticalBar
 
 class EGTGroup(QWidget):
-    def __init__(self, parent=None, cylinders = 4, dbkeys = ["EGT11", "EGT12", "EGT13", "EGT14"]):
+    def __init__(self, parent=None, cylinders = 4, dbkeys = ["EGT11", "EGT12", "EGT13", "EGT14"], data=None):
         super(EGTGroup, self).__init__(parent)
+        self.db_keymap = dict()
         self.setMinimumSize(50, 100)
         self.bars = []
         #self.conversionFunction = lambda x: x * (9.0/5.0) + 32.0
         self.normalizeMode = False
         self.peakMode = False
         for i in range(cylinders):
-            bar = VerticalBar(self)
+            if data:
+                bar = VerticalBar(self,data[dbkeys[i]])
+            else:
+                bar = VerticalBar(self)
             bar.name = str(i+1)
             bar.decimalPlaces = 0
             bar.showUnits = False
@@ -46,9 +50,13 @@ class EGTGroup(QWidget):
             bar.dbkey = dbkeys[i]
             bar.normalizeRange = 400
             self.bars.append(bar)
+            self.db_keymap[dbkeys[i]] = i
         self.smallFontPercent = 0.08
         self.bigFontPercent = 0.10
         hmi.actions.setEgtMode.connect(self.setMode)
+    
+    def setData(self,item,value):
+        self.bars[self.db_keymap[item]].setupGauge()
 
     def setMode(self, args):
         if args.lower() == "normalize":

--- a/pyefis/instruments/gauges/horizontalBar.py
+++ b/pyefis/instruments/gauges/horizontalBar.py
@@ -22,8 +22,8 @@ from PyQt5.QtWidgets import *
 from .abstract import AbstractGauge
 
 class HorizontalBar(AbstractGauge):
-    def __init__(self, parent=None):
-        super(HorizontalBar, self).__init__(parent)
+    def __init__(self, parent=None, data=None):
+        super(HorizontalBar, self).__init__(parent, data)
         self.setMinimumSize(100, 50)
 
     def resizeEvent(self, event):

--- a/pyefis/instruments/gauges/numeric.py
+++ b/pyefis/instruments/gauges/numeric.py
@@ -25,8 +25,8 @@ class NumericDisplay(AbstractGauge):
     """Represents a simple numeric display type gauge.  The benefit of using this
        over a normal text display is that this will change colors properly when
        limits are reached or when failures occur"""
-    def __init__(self, parent=None):
-        super(NumericDisplay, self).__init__(parent)
+    def __init__(self, parent=None, data=None):
+        super(NumericDisplay, self).__init__(parent, data)
         self.alignment = Qt.AlignLeft | Qt.AlignVCenter
         self.unitsAlignment = Qt.AlignRight  | Qt.AlignVCenter
         self.showUnits = False

--- a/pyefis/instruments/gauges/verticalBar.py
+++ b/pyefis/instruments/gauges/verticalBar.py
@@ -22,8 +22,8 @@ from PyQt5.QtWidgets import *
 from .abstract import AbstractGauge
 
 class VerticalBar(AbstractGauge):
-    def __init__(self, parent=None):
-        super(VerticalBar, self).__init__(parent)
+    def __init__(self, parent=None, data=None):
+        super(VerticalBar, self).__init__(parent, data)
         self.setMinimumSize(50, 100)
         self.showValue = True
         self.showUnits = True

--- a/pyefis/instruments/hsi/__init__.py
+++ b/pyefis/instruments/hsi/__init__.py
@@ -78,7 +78,6 @@ class HSI(QGraphicsView):
         self._showGSI = not self.gsidb.old
         self.cardinal = ["N", "E", "S", "W"]
         self.heading_bug = None
-        self._fail = False
         self.myparent = parent
         self.update_period = None
 
@@ -266,8 +265,7 @@ class HSI(QGraphicsView):
     heading = property(getHeading, setHeading)
 
     def setFail(self, fail):
-        if fail != self._fail:
-            self._fail = fail
+        if fail != self.item.fail:
             if self.isVisible():
                 if fail:
                     for l in self.labels:
@@ -336,9 +334,6 @@ class HeadingDisplay(QWidget):
             self.item.oldChanged[bool].connect(self.setOld)
 
         self._heading = self.item.value
-        self._bad = self.item.bad
-        self._old = self.item.old
-        self._fail = self.item.fail
 
         self.font = QFont()
         self.font.setBold(True)
@@ -358,15 +353,15 @@ class HeadingDisplay(QWidget):
         c.setFont(self.font)
         tr = QRectF(0, 0, self.width()-1, self.height()-1)
         c.drawRect(tr)
-        if self._fail:
+        if self.item.fail:
             heading_text = "XXX"
             c.setBrush(QBrush(QColor(Qt.red)))
             c.setPen(QPen(QColor(Qt.red)))
-        elif self._bad:
+        elif self.item.bad:
             heading_text = ""
             c.setBrush(QBrush(QColor(255, 150, 0)))
             c.setPen(QPen(QColor(255, 150, 0)))
-        elif self._old:
+        elif self.item.old:
             heading_text = ""
             c.setBrush(QBrush(QColor(255, 150, 0)))
             c.setPen(QPen(QColor(255, 150, 0)))
@@ -386,15 +381,12 @@ class HeadingDisplay(QWidget):
     heading = property(getHeading, setHeading)
 
     def setFail(self, fail):
-        self._fail = fail
         self.repaint()
 
     def setOld(self, old):
-        self._old = old
         self.repaint()
 
     def setBad(self, bad):
-        self._bad = bad
         self.repaint()
 
 class DG_Tape(QGraphicsView):

--- a/pyefis/instruments/hsi/__init__.py
+++ b/pyefis/instruments/hsi/__init__.py
@@ -274,7 +274,7 @@ class HSI(QGraphicsView):
 
     heading = property(getHeading, setHeading)
 
-    def setFail(self, fail):
+    def setFail(self, fail, item=None):
         if fail != self.item.fail:
             if self.isVisible():
                 if fail:
@@ -393,13 +393,13 @@ class HeadingDisplay(QWidget):
 
     heading = property(getHeading, setHeading)
 
-    def setFail(self, fail):
+    def setFail(self, fail, item=None):
         self.repaint()
 
-    def setOld(self, old):
+    def setOld(self, old, item=None):
         self.repaint()
 
-    def setBad(self, bad):
+    def setBad(self, bad,item=None):
         self.repaint()
 
 class DG_Tape(QGraphicsView):

--- a/pyefis/instruments/hsi/__init__.py
+++ b/pyefis/instruments/hsi/__init__.py
@@ -261,6 +261,16 @@ class HSI(QGraphicsView):
             self._heading = newheading
             self.rotate(-diff)
             self.last_update_time = now
+ 
+    def setData(self,item,value):
+        if item == 'HEAD':
+            self.setHeading(value)
+        elif item == 'COURSE':
+            self.setHeadingBug(value)
+        elif item == 'CDI':
+            self.setCdi(value)
+        elif item == 'GSI':
+            self.setGsi(value)
 
     heading = property(getHeading, setHeading)
 
@@ -378,6 +388,9 @@ class HeadingDisplay(QWidget):
             self._heading = common.bounds(0, 360, heading)
             self.update()
 
+    def setData(self,item,value):
+            self.setHeading(value)
+
     heading = property(getHeading, setHeading)
 
     def setFail(self, fail):
@@ -481,5 +494,7 @@ class DG_Tape(QGraphicsView):
         if heading != self._heading:
             self._heading = heading
             self.redraw()
+    def setData(self,item,value):
+            self.setHeading(value)
 
     heading = property(getHeading, setHeading)

--- a/pyefis/instruments/tc/__init__.py
+++ b/pyefis/instruments/tc/__init__.py
@@ -24,7 +24,7 @@ import pyavtools.fix as fix
 import pyavtools.filters as filters
 
 class TurnCoordinator(QWidget):
-    def __init__(self, parent=None, dial=True, ss_only=False, filter_depth=0):
+    def __init__(self, parent=None, dial=True, ss_only=False, filter_depth=0, data=None):
         super(TurnCoordinator, self).__init__(parent)
         self.myparent = parent
         self.slip_skid_only = ss_only
@@ -41,16 +41,22 @@ class TurnCoordinator(QWidget):
             self.filter = filters.AvgFilter(filter_depth)
         else:
             self.filter = None
-        self.alat_item = fix.db.get_item("ALAT")
-        self.alat_item.valueChanged[float].connect(self.setLatAcc)
-        self.alat_item.badChanged.connect(self.quality_change)
-        self.alat_item.oldChanged.connect(self.quality_change)
-        self.alat_item.failChanged.connect(self.quality_change)
-        self.rot_item = fix.db.get_item("ROT")
-        self.rot_item.valueChanged[float].connect(self.setROT)
-        self.rot_item.badChanged.connect(self.quality_change)
-        self.rot_item.oldChanged.connect(self.quality_change)
-        self.rot_item.failChanged.connect(self.quality_change)
+
+        if data:
+            self.alat_item = data["ALAT"]
+            self.rot_item = data['ROT']
+        else:
+            self.alat_item = fix.db.get_item("ALAT")
+            self.alat_item.valueChanged[float].connect(self.setLatAcc)
+            self.alat_item.badChanged.connect(self.quality_change)
+            self.alat_item.oldChanged.connect(self.quality_change)
+            self.alat_item.failChanged.connect(self.quality_change)
+            self.rot_item = fix.db.get_item("ROT")
+            self.rot_item.valueChanged[float].connect(self.setROT)
+            self.rot_item.badChanged.connect(self.quality_change)
+            self.rot_item.oldChanged.connect(self.quality_change)
+            self.rot_item.failChanged.connect(self.quality_change)
+
         self.alat_multiplier = 1.0 / (0.217)
         self.max_tc_displacement = 1.0 / self.alat_multiplier
 

--- a/pyefis/instruments/tc/__init__.py
+++ b/pyefis/instruments/tc/__init__.py
@@ -235,6 +235,11 @@ class TurnCoordinator(QWidget):
             self._latAcc = acc
         if last_acc != self._latAcc:
             self.update()
+    def setData(self, item, value):
+        if item == 'ALAT':
+            self.setLatAcc(value)
+        elif item == 'ROT':
+            self.setROT(value)
 
     latAcc = property(getLatAcc, setLatAcc)
 

--- a/pyefis/instruments/vsi/__init__.py
+++ b/pyefis/instruments/vsi/__init__.py
@@ -514,7 +514,7 @@ class Alt_Trend_Tape(QGraphicsView):
 
     def getBad(self):
         return self._bad
-    def setBad(self, b):
+    def setBad(self, b,item=None):
         if self._bad != b:
             self._bad = b
             self.redraw()
@@ -522,7 +522,7 @@ class Alt_Trend_Tape(QGraphicsView):
 
     def getOld(self):
         return self._old
-    def setOld(self, b):
+    def setOld(self, b, item=None):
         if self._old != b:
             self._old = b
             self.redraw()
@@ -530,7 +530,7 @@ class Alt_Trend_Tape(QGraphicsView):
 
     def getFail(self):
         return self._fail
-    def setFail(self, b):
+    def setFail(self, b, item=None):
         if self._fail != b:
             self._fail = b
             self.redraw()

--- a/pyefis/instruments/vsi/__init__.py
+++ b/pyefis/instruments/vsi/__init__.py
@@ -26,7 +26,7 @@ import pyavtools.fix as fix
 
 class VSI_Dial(QWidget):
     FULL_WIDTH = 300
-    def __init__(self, parent=None, fontsize=20):
+    def __init__(self, parent=None, fontsize=20,data=None):
         super(VSI_Dial, self).__init__(parent)
         self.setStyleSheet("border: 0px")
         self.setFocusPolicy(Qt.NoFocus)
@@ -34,11 +34,14 @@ class VSI_Dial(QWidget):
         self._roc = 0
         self.maxRange = 2000
         self.maxAngle = 170.0
-        self.item = fix.db.get_item("VS")
-        self.item.valueChanged[float].connect(self.setROC)
-        self.item.oldChanged[bool].connect(self.repaint)
-        self.item.badChanged[bool].connect(self.repaint)
-        self.item.failChanged[bool].connect(self.repaint)
+        if data:
+            self.item=data
+        else:
+            self.item = fix.db.get_item("VS")
+            self.item.valueChanged[float].connect(self.setROC)
+            self.item.oldChanged[bool].connect(self.repaint)
+            self.item.badChanged[bool].connect(self.repaint)
+            self.item.failChanged[bool].connect(self.repaint)
 
     def resizeEvent(self, event):
         self.background = QPixmap(self.width(), self.height())
@@ -179,7 +182,6 @@ class VSI_Dial(QWidget):
             dial.drawText (0,0,w,h, Qt.AlignCenter, "OLD")
         """
 
-
     def getROC(self):
         return self._roc
 
@@ -192,7 +194,7 @@ class VSI_Dial(QWidget):
 
 
 class VSI_PFD(QWidget):
-    def __init__(self, parent=None, fontsize=15):
+    def __init__(self, parent=None, fontsize=15, data=None):
         super(VSI_PFD, self).__init__(parent)
         self.setStyleSheet("background-color: rgba(0, 0, 0, 0%); border: 0px")
         self.setFocusPolicy(Qt.NoFocus)
@@ -200,11 +202,14 @@ class VSI_PFD(QWidget):
         self.marks = [(500,""),(1000,"1"),(1500,""),(2000,"2")]
         self.scaleRoot = 0.7
         self._value = 0
-        self.item = fix.db.get_item("VS")
-        self.item.valueChanged[float].connect(self.setValue)
-        self.item.oldChanged[bool].connect(self.repaint)
-        self.item.badChanged[bool].connect(self.repaint)
-        self.item.failChanged[bool].connect(self.repaint)
+        if data:
+            self.item=data
+        else:
+            self.item = fix.db.get_item("VS")
+            self.item.valueChanged[float].connect(self.setValue)
+            self.item.oldChanged[bool].connect(self.repaint)
+            self.item.badChanged[bool].connect(self.repaint)
+            self.item.failChanged[bool].connect(self.repaint)
 
     def resizeEvent(self, event):
         # Just for convenience

--- a/pyefis/instruments/vsi/__init__.py
+++ b/pyefis/instruments/vsi/__init__.py
@@ -190,6 +190,9 @@ class VSI_Dial(QWidget):
             self._roc = roc
             self.update()
 
+    def setData(self, item, value):
+        self.setROC(value)
+
     roc = property(getROC, setROC)
 
 
@@ -284,6 +287,9 @@ class VSI_PFD(QWidget):
     def setValue(self, value):
         self._value = value
         self.update()
+
+    def setData(self, item, value):
+        self.setValue(value)
 
     value = property(getValue, setValue)
 
@@ -486,6 +492,9 @@ class Alt_Trend_Tape(QGraphicsView):
         if vs != self._vs:
             self._vs = vs
             self.redraw()
+
+    def setData(self, item, value):
+        self.Vs(value)
 
     vs = property(setVs)
 

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -94,6 +94,7 @@ class Screen(QWidget):
                 for g in i['groups']:
                     for gi in g['instruments']:
                         gi['type'] = i['type'].replace('ganged_','')
+                        gi['options'] = g.get('common_options', dict())|gi.get('options',dict()) #Merge with common_options losing the the instrument
                         self.setup_instruments(count,gi,ganged=True)
 
                         count += 1     

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -320,11 +320,14 @@ class Screen(QWidget):
                         y = grid_y + (( grid_height - height) / 2) 
             print(f"{x} {y} {width} {height}")
             self.move_resize_inst(i,qRound(x),qRound(y),qRound(width),qRound(height))
-            
+            try:
+                self.instruments[i].setupGauge()
+            except:
+                pass
+
     def move_resize_inst(self,inst,x,y,width,height):
         self.instruments[inst].move(x,y)
         self.instruments[inst].resize(width,height)
-
 
     def resizeEvent(self, event):
         if not self.init:

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -1,0 +1,246 @@
+#  Copyright (c) 2016 Phil Birkelbach
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+from PyQt5.QtGui import *
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
+
+from pyefis.instruments import ai
+# from pyefis.instruments import gauges
+from pyefis.instruments import hsi
+from pyefis.instruments import airspeed
+from pyefis.instruments import altimeter
+from pyefis.instruments import vsi
+from pyefis.instruments import tc
+
+import pyavtools.fix as fix
+from collections import defaultdict
+
+class Screen(QWidget):
+    def __init__(self, parent=None,config=None):
+        super(Screen, self).__init__(parent)
+        self.parent = parent
+        p = self.parent.palette()
+        self.screenColor = (0, 0, 0)
+        if self.screenColor:
+            p.setColor(self.backgroundRole(), QColor(*self.screenColor))
+            self.setPalette(p)
+            self.setAutoFillBackground(True)
+
+        #self.airspeed = airspeed.Airspeed(self)
+
+        #self.ai = ai.AI(self)
+        #self.ai.fontSize = 12
+        #self.ai.bankMarkSize = 7
+        #self.ai.pitchDegreesShown = 60
+
+        #self.altimeter = altimeter.Altimeter(self)
+
+        #self.tc = tc.TurnCoordinator(self)
+
+        #self.hsi = hsi.HSI(self, font_size=12, fgcolor=Qt.white)
+        self.heading_disp = hsi.HeadingDisplay(self, font_size=17, fgcolor=Qt.white)
+
+        self.init= False
+        self.ai_mapping = dict()
+        self.tc_mapping = dict()
+        self.hsi_mapping = dict()
+
+    def init_screen(self):
+        self.layout = self.parent.get_config_item(self,'layout')
+        self.data_items = dict()
+        self.data_distribution = defaultdict(list)
+        self.insturments = dict()
+        self.insturment_config = dict ()
+        # Setup insturments:
+        count = 1
+        for i in self.get_config_item('insturments'):
+            self.insturment_config[count] = i
+            if type(i['db_items']) is list:
+                for item in i['db_items']:
+                    self.define_data(count,item)
+                    self.data_distribution[item].append(count)
+            else:
+                self.define_data(count,i['db_items'])
+                self.data_distribution[i['db_items']].append(count)
+            # Process the type of gauge this is
+            if i['type'] == 'vsi_dial':
+                self.insturments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
+            elif i['type'] == 'altimeter_dial':
+                self.insturments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
+            elif i['type'] == 'airspeed_dial':
+                self.insturments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
+            elif i['type'] == 'atitude_indicator':
+                self.ai_mapping['PITCH'] = self.lookup_mapping('PITCH',i.get('mapping',dict()))
+                self.ai_mapping['ROLL'] = self.lookup_mapping('ROLL',i.get('mapping',dict()))
+                self.ai_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
+                self.ai_mapping['TAS'] = self.lookup_mapping('TAS',i.get('mapping',dict()))
+
+                self.insturments[count] = ai.AI(self,data = {
+                    'PITCH': self.data_items[self.ai_mapping['PITCH']],
+                    'ROLL':  self.data_items[self.ai_mapping['ROLL']],
+                    'ALAT':  self.data_items[self.ai_mapping['ALAT']],
+                    'TAS':   self.data_items[self.ai_mapping['TAS']]
+                    }
+                )
+
+                self.insturments[count].fontSize = i.get('options',{"fontSize": 12}).get('fontSize', 12)
+                self.insturments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
+                self.insturments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
+            elif i['type'] == 'turn_coordinator':
+                self.tc_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
+                self.tc_mapping['ROT'] = self.lookup_mapping('ROT',i.get('mapping',dict()))
+
+                self.insturments[count] = tc.TurnCoordinator(self,data ={
+                    'ALAT': self.data_items[self.tc_mapping['ALAT']],
+                    'ROT': self.data_items[self.tc_mapping['ROT']],
+                    }
+                )
+            elif i['type'] == 'horizontal_situation_indicator':
+
+                self.hsi_mapping['COURSE'] = self.lookup_mapping('COURSE',i.get('mapping',dict()))
+                self.hsi_mapping['CDI'] = self.lookup_mapping('CDI',i.get('mapping',dict()))
+                self.hsi_mapping['GSI'] = self.lookup_mapping('GSI',i.get('mapping',dict()))
+                self.hsi_mapping['HEAD'] = self.lookup_mapping('HEAD',i.get('mapping',dict()))
+
+                self.insturments[count] = hsi.HSI(self,data ={
+                    'COURSE': self.data_items[self.hsi_mapping['COURSE']],
+                    'CDI': self.data_items[self.hsi_mapping['CDI']],
+                    'GSI': self.data_items[self.hsi_mapping['GSI']],
+                    'HEAD': self.data_items[self.hsi_mapping['HEAD']],
+                    }
+                )
+                self.insturments[count].gsi_enabled = i.get('options',{"gsi_enabled": True}).get('gsi_enabled', True)
+                self.insturments[count].cdi_enabled = i.get('options',{"cdi_enabled": True}).get('cdi_enabled', True)
+
+
+            count += 1
+        #Place insturments:
+        if self.layout['type'] == 'grid':
+            self.grid_layout()
+        self.init = True
+
+    def lookup_mapping(self,item,mapping=dict()):
+          return mapping.get(item,item)
+
+    def define_data(self,count,item):
+        if not item in self.data_items:
+            print(f"db item: {item}")
+            self.data_items[item] = fix.db.get_item(item)
+            self.data_items[item].valueChanged[float].connect(lambda valueChanged, key=item: self.data_modified(db_item=key) )
+            self.data_items[item].valueChanged[str].connect(lambda valueChanged, key=item: self.data_modified(db_item=key))
+            self.data_items[item].valueChanged[bool].connect(lambda valueChanged, key=item: self.data_modified(db_item=key))
+            self.data_items[item].oldChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
+            self.data_items[item].badChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
+            self.data_items[item].failChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
+
+
+    def data_modified(self,db_item):
+        print(f"modified: {db_item}")
+        for inst in self.data_distribution[db_item]:
+            if self.insturment_config[inst]['type'] == 'vsi_dial':
+                self.insturments[inst].setROC(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'altimeter_dial':
+                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'airspeed_dial':
+                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'atitude_indicator':
+                self.insturments[inst].setPitchAngle(self.data_items[self.ai_mapping['PITCH']].value)
+                self.insturments[inst].setRollAngle(self.data_items[self.ai_mapping['ROLL']].value)
+                self.insturments[inst].setLateralAcceleration(self.data_items[self.ai_mapping['ALAT']].value)
+                self.insturments[inst].setTrueAirspeed(self.data_items[self.ai_mapping['TAS']].value)
+            elif self.insturment_config[inst]['type'] == 'turn_coordinator':
+                self.insturments[inst].setLatAcc(self.data_items[self.tc_mapping['ALAT']].value)
+                self.insturments[inst].setROT(self.data_items[self.tc_mapping['ROT']].value)
+            elif self.insturment_config[inst]['type'] == 'horizontal_situation_indicator':
+                self.insturments[inst].setHeadingBug(self.data_items[self.hsi_mapping['COURSE']].value)
+                self.insturments[inst].setCdi(self.data_items[self.hsi_mapping['CDI']].value)
+                self.insturments[inst].setGsi(self.data_items[self.hsi_mapping['GSI']].value)
+                self.insturments[inst].setHeading(self.data_items[self.hsi_mapping['HEAD']].value)
+
+
+
+
+
+    def data_redraw(self,db_item):
+        print(f"redraw: {db_item}")
+        for inst in self.data_distribution[db_item]:
+            if self.insturment_config[inst]['type'] == 'vsi_dial':
+                self.insturments[inst].setROC(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'altimeter_dial':
+                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'airspeed_dial':
+                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+
+            self.insturments[inst].update()
+            
+
+    def grid_layout(self):
+        count = 1
+        for i,c in self.insturment_config.items():
+            width = qRound(self.width() / self.layout['columns'])
+            height = qRound(self.height() / self.layout['rows'])
+            x = qRound(width * (c['column'] - 1) )
+            y = qRound(height * (c['row'] - 1) )
+            print(f"width={width} height={height} x={x} y={y}")
+            self.move_resize_inst(i,x,y,width,height)
+            
+    def move_resize_inst(self,inst,x,y,width,height):
+        self.insturments[inst].move(x,y)
+        self.insturments[inst].resize(width,height)
+        #self.insturments[inst].show()
+
+    def vsi_dial(self,count=None,db=None):
+        self.insturments[count] = vsi.VSI_Dial(self,data=db)
+        #self.db.valueChanged[float].connect(self.insturments[count].setROC)
+        #self.db.oldChanged[bool].connect(self.insturments[count].repaint)
+        #self.db.badChanged[bool].connect(self.insturments[count].repaint)
+        #self.db.failChanged[bool].connect(self.insturments[count].repaint)
+
+    def resizeEvent(self, event):
+        if not self.init:
+            self.init_screen()
+        menu_offset = 30
+        instWidth = qRound(self.width()/3)
+        instHeight = qRound((self.height()-menu_offset)/2)
+        diameter=min(instWidth,instHeight)
+
+        #self.airspeed.move(0,menu_offset)
+        #self.airspeed.resize(instWidth,instHeight)
+
+        #self.ai.move(instWidth, 0 + menu_offset)
+        #self.ai.resize(instWidth, instHeight)
+
+        #self.altimeter.move(instWidth*2, 0 + menu_offset)
+        #self.altimeter.resize(instWidth,instHeight)
+
+        #self.tc.move(0, instHeight + menu_offset)
+        #self.tc.resize(instWidth, instHeight)
+
+        hdh = self.heading_disp.height()
+        hdw = self.heading_disp.width()
+        hsi_diameter = diameter - (hdh+30)
+        offset = instHeight-hsi_diameter
+        #self.hsi.move(qRound(instWidth+(instWidth-hsi_diameter)/2), qRound(instHeight + menu_offset + offset-20))
+        #self.hsi.resize(hsi_diameter,hsi_diameter)
+        self.heading_disp.move(qRound(instWidth*1.5-hdw/2), qRound(instHeight + menu_offset+10))
+
+        #self.vsi.move(instWidth * 2, instHeight + menu_offset)
+        #self.vsi.resize(instWidth, instHeight)
+        if self.layout['type'] == 'grid':
+            self.grid_layout()
+    def get_config_item(self, key):
+        return self.parent.get_config_item(self, key)

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -27,6 +27,7 @@ from pyefis.instruments import vsi
 from pyefis.instruments import tc
 from pyefis.instruments import gauges
 from pyefis.instruments import misc
+from pyefis.instruments.ai.VirtualVfr import VirtualVfr
 
 import pyavtools.fix as fix
 from collections import defaultdict
@@ -64,6 +65,7 @@ class Screen(QWidget):
         # atitude_indicator
         # egt_vertical_bar_gauge
         # heading_display
+        # heading_tape
         # horizontal_bar_gauge
         # horizontal_situation_indicator
         # turn_coordinator
@@ -172,6 +174,8 @@ class Screen(QWidget):
             self.instruments[count] = altimeter.Altimeter_Tape(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'heading_display':
             self.instruments[count] = hsi.HeadingDisplay(self,data=self.data_items[db_items[0]])
+        elif i['type'] == 'heading_tape':
+            self.instruments[count] = hsi.DG_Tape(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'horizontal_situation_indicator':
             self.instruments[count] = hsi.HSI(self,data=self.get_data_dict(count))
         elif i['type'] == 'turn_coordinator':
@@ -187,6 +191,9 @@ class Screen(QWidget):
             self.instruments[count] = gauges.VerticalBar(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'egt_vertical_bar_gauge':
             self.instruments[count] = gauges.EGTGroup(self,data=self.get_data_dict(count),dbkeys=db_items,cylinders=i['options']['cylinders'])
+        elif i['type'] == 'virtual_vfr':
+            self.instruments[count] = VirtualVfr(self,data=self.get_data_dict(count))
+
          # Set options
         if 'options' in i:
             #loop over each option
@@ -227,7 +234,7 @@ class Screen(QWidget):
             return ['ALT']
         elif 'atitude_indicator' == inst:
             return ['PITCH','ROLL','ALAT','TAS']
-        elif 'heading_display' == inst:
+        elif inst in [ 'heading_display', 'heading_tape']:
             return ['HEAD']
         elif 'horizontal_situation_indicator' == inst:
             return ['COURSE','CDI','GSI','HEAD']
@@ -235,6 +242,8 @@ class Screen(QWidget):
             return ['ROT','ALAT']
         elif 'vsi_dial' == inst:
             return ['VS']
+        elif 'virtual_vfr' == inst:
+            return ['PITCH','LAT','LONG','HEAD','ALT','PITCH','ROLL','ALAT','TAS']
 
     def get_instrument_default_options(self, inst):
         if i['type'] == 'heading_display':

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -154,6 +154,7 @@ class Screen(QWidget):
         for item in db_items:
             self.define_data(count,item,i['type'])
             self.data_distribution[item].append(count)
+
         # Process the type of instrument this is and create them
         if i['type'] == 'airspeed_dial':
             self.instruments[count] = airspeed.Airspeed(self,data=self.data_items[db_items[0]])
@@ -192,7 +193,7 @@ class Screen(QWidget):
         elif i['type'] == 'egt_vertical_bar_gauge':
             self.instruments[count] = gauges.EGTGroup(self,data=self.get_data_dict(count),dbkeys=db_items,cylinders=i['options']['cylinders'])
         elif i['type'] == 'virtual_vfr':
-            self.instruments[count] = VirtualVfr(self,data=self.get_data_dict(count))
+            self.instruments[count] = VirtualVfr(self,data=self.get_data_dict2(count))
 
          # Set options
         if 'options' in i:
@@ -210,7 +211,9 @@ class Screen(QWidget):
                     hmi.actions.setInstUnits.connect(self.instruments[count].setUnits)
                 else:
                     setattr(self.instruments[count], option, value)
-        self.define_signals(count,item,i['type'])
+
+        for item in db_items:
+            self.define_signals(count,item,i['type'])
 
     def get_data_dict(self,inst):
         #Returns a dict with the data items a multi-item gauge needs
@@ -282,33 +285,36 @@ class Screen(QWidget):
 
         if hasattr( self.instruments[count], 'setOld') :
             # Init the signal in the item
-            self.instruments[count].setOld(self.data_items[item].old)
+            print(f"Init setOld {item}")
+            self.instruments[count].setOld(self.data_items[item].old,item)
             self.data_items[item].oldChanged[bool].connect(lambda oldChanged, key=item: self.setOld(db_item=key))
             self.data_item_signals_defined[item][count] = 'setOld'
             self.data_signal_routing[item]['setOld'].append(count)
         if hasattr( self.instruments[count], 'setBad') :
+            print(f"Init setBad {item}")
             # Init the signal in the item
-            self.instruments[count].setBad(self.data_items[item].bad)
-            self.data_items[item].badChanged[bool].connect(lambda oldChanged, key=item: self.setBad(db_item=key))
+            self.instruments[count].setBad(self.data_items[item].bad,item)
+            self.data_items[item].badChanged[bool].connect(lambda badChanged, key=item: self.setBad(db_item=key))
             self.data_item_signals_defined[item][count] = 'setBad'
             self.data_signal_routing[item]['setBad'].append(count)
         if hasattr( self.instruments[count], 'setFail') :
+            print(f"Init setFail {item}")
             # Init the signal in the item
-            self.instruments[count].setFail(self.data_items[item].fail)
-            self.data_items[item].failChanged[bool].connect(lambda oldChanged, key=item: self.setFail(db_item=key))
+            self.instruments[count].setFail(self.data_items[item].fail,item)
+            self.data_items[item].failChanged[bool].connect(lambda failChanged, key=item: self.setFail(db_item=key))
             self.data_item_signals_defined[item][count] = 'setFail'
             self.data_signal_routing[item]['setFail'].append(count)
 
         if hasattr( self.instruments[count], 'setAux') :
             # Init the signal in the item
-            self.instruments[count].setAux(self.data_items[item].aux)
+            self.instruments[count].setAux(self.data_items[item].aux,item)
             self.data_items[item].auxChanged[bool].connect(lambda oldChanged, key=item: self.setAux(db_item=key))
             self.data_item_signals_defined[item][count] = 'setAux'
             self.data_signal_routing[item]['setAux'].append(count)
 
         if hasattr( self.instruments[count], 'setAnnunciate') :
             # Init the signal in the item
-            self.instruments[count].setAnnunciate(self.data_items[item].annunciate)
+            self.instruments[count].setAnnunciate(self.data_items[item].annunciate,item)
             self.data_items[item].annunciateChanged[bool].connect(lambda oldChanged, key=item: self.setAnnunciate(db_item=key))
             self.data_item_signals_defined[item][count] = 'setAnn'
             self.data_signal_routing[item]['setAnn'].append(count)
@@ -369,31 +375,35 @@ class Screen(QWidget):
             self.instruments[inst].setData(db_item,self.data_items[db_item].value)
 
     def setOld(self,db_item):
+        print(f"In setOld for {db_item} ##############################")
         for inst in self.data_signal_routing[db_item]['setOld']:
             logger.debug(f"Calling setOld for {inst} {type(self.instruments[inst])}")
-            self.instruments[inst].setOld(self.data_items[db_item].old)
+            self.instruments[inst].setOld(self.data_items[db_item].old, item=db_item)
 
     def setBad(self,db_item):
+        print(f"In setBad for {db_item} ##############################")
         for inst in self.data_signal_routing[db_item]['setBad']:
             logger.debug(f"Calling setBad for {inst} {type(self.instruments[inst])}")
-            self.instruments[inst].setBad(self.data_items[db_item].bad)
+            self.instruments[inst].setBad(self.data_items[db_item].bad, item=db_item)
 
     def setFail(self,db_item):
+        print(f"In setFail for {db_item} ##############################")
         for inst in self.data_signal_routing[db_item]['setFail']:
             logger.debug(f"Calling setFail for {inst} {type(self.instruments[inst])}")
-            self.instruments[inst].setFail(self.data_items[db_item].fail)
+            self.instruments[inst].setFail(self.data_items[db_item].fail, item=db_item)
 
     def setAux(self,db_item):
         for inst in self.data_signal_routing[db_item]['setAux']:
             logger.debug(f"Calling setAux for {inst} {type(self.instruments[inst])}")
-            self.instruments[inst].setAux(self.data_items[db_item].aux)
+            self.instruments[inst].setAux(self.data_items[db_item].aux, item=db_item)
 
     def setAnnunciate(self,db_item):
         for inst in self.data_signal_routing[db_item]['setAnn']:
             logger.debug(f"Calling setAnnunciate for {inst} {type(self.instruments[inst])}")
-            self.instruments[inst].setAnnunciate(self.data_items[db_item].annunciate)
+            self.instruments[inst].setAnnunciate(self.data_items[db_item].annunciate, item=db_item)
 
     def report_received(self,db_item='t',signal='unknown'):
+        # Not sure if we need to do more here or not
         for inst in self.data_signal_routing[db_item]['report']:
             self.instruments[inst].setupGauge()
             logger.debug(f"report: {signal} signal for: {db_item}:{self.data_items[db_item].value} {type(self.instruments[inst])}")

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -183,11 +183,25 @@ class Screen(QWidget):
     def grid_layout(self):
         count = 1
         for i,c in self.insturment_config.items():
-            grid_width = self.width() / int(self.layout['columns'])
-            grid_height = self.height() / int(self.layout['rows'])
-            grid_x = grid_width * (int(c['column']) - 1) 
-            grid_y = grid_height * (int(c['row']) - 1) 
+            topm = 0
+            leftm = 0
+            rightm = 0
+            bottomm = 0
+            # Margins in %
+            if 'margin' in self.layout:
+                if 'top' in self.layout['margin'] and self.layout['margin']['top'] > 0 and self.layout['margin']['top'] < 100:
+                    topm = self.height() * ( self.layout['margin']['top'] / 100 )
+                if 'bottom' in self.layout['margin'] and self.layout['margin']['bottom'] > 0 and self.layout['margin']['bottom'] < 100:
+                    bottomm = self.height() * ( self.layout['margin']['bottom'] / 100 )
+                if 'left' in self.layout['margin'] and self.layout['margin']['left'] > 0 and self.layout['margin']['left'] < 100:
+                    leftm = self.height() * ( self.layout['margin']['left'] / 100 )
+                if 'right' in self.layout['margin'] and self.layout['margin']['right'] > 0 and self.layout['margin']['right'] < 100:
+                    rightm = self.height() * ( self.layout['margin']['right'] / 100 )
 
+            grid_width = ( self.width() - leftm - rightm ) / int(self.layout['columns'])
+            grid_height = ( self.height() - topm - bottomm ) / int(self.layout['rows'])
+            grid_x = leftm + grid_width * (int(c['column']) - 1) 
+            grid_y = topm + grid_height * (int(c['row']) - 1) 
             # Span columns to the right and rows down
             if 'span' in c:
                 if 'rows' in c['span']:

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -30,6 +30,10 @@ from pyefis.instruments import misc
 
 import pyavtools.fix as fix
 from collections import defaultdict
+import re
+
+funcTempF = lambda x: x * (9.0/5.0) + 32.0 
+funcTempC = lambda x: x
 
 class Screen(QWidget):
     def __init__(self, parent=None,config=None):
@@ -52,8 +56,10 @@ class Screen(QWidget):
         # arc_gauge
         # atitude_indicator
         # heading_display
+        # horizontal_bar_gauge
         # horizontal_situation_indicator
         # turn_coordinator
+        # vertical_bar_gauge
         # vsi_dial
         # vsi_pfd  # Testing to do
 
@@ -120,12 +126,22 @@ class Screen(QWidget):
             # Gauges
             elif i['type'] == 'arc_gauge':
                 self.instruments[count] = gauges.ArcGauge(self,data=self.data_items[db_items[0]])
+            elif i['type'] == 'horizontal_bar_gauge':
+                self.instruments[count] = gauges.HorizontalBar(self,data=self.data_items[db_items[0]])
+            elif i['type'] == 'vertical_bar_gauge':
+                self.instruments[count] = gauges.VerticalBar(self,data=self.data_items[db_items[0]])
 
             # Set options
             if 'options' in i:
                 #loop over each option
                 for option,value in i['options'].items():
-                    setattr(self.instruments[count], option, value)
+                    if 'temperature' in option and value == True:
+                        setattr(self.instruments[count], 'unitFunction1', funcTempF)
+                        setattr(self.instruments[count], 'units1', u'\N{DEGREE SIGN}F')
+                        setattr(self.instruments[count], 'unitFunction2', funcTempC)
+                        setattr(self.instruments[count], 'units2', u'\N{DEGREE SIGN}C')
+                    else:
+                        setattr(self.instruments[count], option, value)
 
             count += 1
         #Place instruments:

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -49,11 +49,11 @@ class Screen(QWidget):
         self.layout = self.parent.get_config_item(self,'layout')
         self.data_items = dict()
         self.data_distribution = defaultdict(list)
-        self.insturments = dict()
+        self.instruments = dict()
         self.insturment_config = dict ()
-        # Setup insturments:
+        # Setup instruments:
         count = 1
-        for i in self.get_config_item('insturments'):
+        for i in self.get_config_item('instruments'):
             self.insturment_config[count] = i
             if type(i['db_items']) is list:
                 for item in i['db_items']:
@@ -64,18 +64,18 @@ class Screen(QWidget):
                 self.data_distribution[i['db_items']].append(count)
             # Process the type of gauge this is
             if i['type'] == 'vsi_dial':
-                self.insturments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
+                self.instruments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
             elif i['type'] == 'altimeter_dial':
-                self.insturments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
+                self.instruments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
             elif i['type'] == 'airspeed_dial':
-                self.insturments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
+                self.instruments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
             elif i['type'] == 'atitude_indicator':
                 self.ai_mapping['PITCH'] = self.lookup_mapping('PITCH',i.get('mapping',dict()))
                 self.ai_mapping['ROLL'] = self.lookup_mapping('ROLL',i.get('mapping',dict()))
                 self.ai_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
                 self.ai_mapping['TAS'] = self.lookup_mapping('TAS',i.get('mapping',dict()))
 
-                self.insturments[count] = ai.AI(self,data = {
+                self.instruments[count] = ai.AI(self,data = {
                     'PITCH': self.data_items[self.ai_mapping['PITCH']],
                     'ROLL':  self.data_items[self.ai_mapping['ROLL']],
                     'ALAT':  self.data_items[self.ai_mapping['ALAT']],
@@ -83,14 +83,14 @@ class Screen(QWidget):
                     }
                 )
 
-                self.insturments[count].fontSize = i.get('options',{"font_size": 12}).get('font_size', 12)
-                self.insturments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
-                self.insturments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
+                self.instruments[count].fontSize = i.get('options',{"font_size": 12}).get('font_size', 12)
+                self.instruments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
+                self.instruments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
             elif i['type'] == 'turn_coordinator':
                 self.tc_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
                 self.tc_mapping['ROT'] = self.lookup_mapping('ROT',i.get('mapping',dict()))
 
-                self.insturments[count] = tc.TurnCoordinator(self,data ={
+                self.instruments[count] = tc.TurnCoordinator(self,data ={
                     'ALAT': self.data_items[self.tc_mapping['ALAT']],
                     'ROT': self.data_items[self.tc_mapping['ROT']],
                     }
@@ -102,22 +102,22 @@ class Screen(QWidget):
                 self.hsi_mapping['GSI'] = self.lookup_mapping('GSI',i.get('mapping',dict()))
                 self.hsi_mapping['HEAD'] = self.lookup_mapping('HEAD',i.get('mapping',dict()))
 
-                self.insturments[count] = hsi.HSI(self,data ={
+                self.instruments[count] = hsi.HSI(self,data ={
                     'COURSE': self.data_items[self.hsi_mapping['COURSE']],
                     'CDI': self.data_items[self.hsi_mapping['CDI']],
                     'GSI': self.data_items[self.hsi_mapping['GSI']],
                     'HEAD': self.data_items[self.hsi_mapping['HEAD']],
                     }
                 )
-                self.insturments[count].gsi_enabled = i.get('options',{"gsi_enabled": True}).get('gsi_enabled', True)
-                self.insturments[count].cdi_enabled = i.get('options',{"cdi_enabled": True}).get('cdi_enabled', True)
+                self.instruments[count].gsi_enabled = i.get('options',{"gsi_enabled": True}).get('gsi_enabled', True)
+                self.instruments[count].cdi_enabled = i.get('options',{"cdi_enabled": True}).get('cdi_enabled', True)
             elif i['type'] == 'heading_display':
-                self.insturments[count] = hsi.HeadingDisplay(self,data=self.data_items[self.lookup_mapping('HEAD',i.get('mapping',dict()))])
-                self.insturments[count].font_size = self.insturments[count].font_size = i.get('options',{"font_size": 17}).get('font_size', 17)  
+                self.instruments[count] = hsi.HeadingDisplay(self,data=self.data_items[self.lookup_mapping('HEAD',i.get('mapping',dict()))])
+                self.instruments[count].font_size = self.instruments[count].font_size = i.get('options',{"font_size": 17}).get('font_size', 17)  
 
 
             count += 1
-        #Place insturments:
+        #Place instruments:
         if self.layout['type'] == 'grid':
             self.grid_layout()
         self.init = True
@@ -141,27 +141,27 @@ class Screen(QWidget):
         print(f"modified: {db_item}")
         for inst in self.data_distribution[db_item]:
             if self.insturment_config[inst]['type'] == 'vsi_dial':
-                self.insturments[inst].setROC(self.data_items[db_item].value)
+                self.instruments[inst].setROC(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'altimeter_dial':
-                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+                self.instruments[inst].setAltimeter(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'airspeed_dial':
-                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+                self.instruments[inst].setAirspeed(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'atitude_indicator':
                 # Should verify each and only update if for example db_item = 'PITCH'
-                self.insturments[inst].setPitchAngle(self.data_items[self.ai_mapping['PITCH']].value)
-                self.insturments[inst].setRollAngle(self.data_items[self.ai_mapping['ROLL']].value)
-                self.insturments[inst].setLateralAcceleration(self.data_items[self.ai_mapping['ALAT']].value)
-                self.insturments[inst].setTrueAirspeed(self.data_items[self.ai_mapping['TAS']].value)
+                self.instruments[inst].setPitchAngle(self.data_items[self.ai_mapping['PITCH']].value)
+                self.instruments[inst].setRollAngle(self.data_items[self.ai_mapping['ROLL']].value)
+                self.instruments[inst].setLateralAcceleration(self.data_items[self.ai_mapping['ALAT']].value)
+                self.instruments[inst].setTrueAirspeed(self.data_items[self.ai_mapping['TAS']].value)
             elif self.insturment_config[inst]['type'] == 'turn_coordinator':
-                self.insturments[inst].setLatAcc(self.data_items[self.tc_mapping['ALAT']].value)
-                self.insturments[inst].setROT(self.data_items[self.tc_mapping['ROT']].value)
+                self.instruments[inst].setLatAcc(self.data_items[self.tc_mapping['ALAT']].value)
+                self.instruments[inst].setROT(self.data_items[self.tc_mapping['ROT']].value)
             elif self.insturment_config[inst]['type'] == 'horizontal_situation_indicator':
-                self.insturments[inst].setHeadingBug(self.data_items[self.hsi_mapping['COURSE']].value)
-                self.insturments[inst].setCdi(self.data_items[self.hsi_mapping['CDI']].value)
-                self.insturments[inst].setGsi(self.data_items[self.hsi_mapping['GSI']].value)
-                self.insturments[inst].setHeading(self.data_items[self.hsi_mapping['HEAD']].value)
+                self.instruments[inst].setHeadingBug(self.data_items[self.hsi_mapping['COURSE']].value)
+                self.instruments[inst].setCdi(self.data_items[self.hsi_mapping['CDI']].value)
+                self.instruments[inst].setGsi(self.data_items[self.hsi_mapping['GSI']].value)
+                self.instruments[inst].setHeading(self.data_items[self.hsi_mapping['HEAD']].value)
             elif self.insturment_config[inst]['type'] == 'heading_display':
-                self.insturments[inst].setHeading(self.data_items[db_item].value)
+                self.instruments[inst].setHeading(self.data_items[db_item].value)
 
 
 
@@ -169,15 +169,15 @@ class Screen(QWidget):
         print(f"redraw: {db_item}")
         for inst in self.data_distribution[db_item]:
             if self.insturment_config[inst]['type'] == 'vsi_dial':
-                self.insturments[inst].setROC(self.data_items[db_item].value)
+                self.instruments[inst].setROC(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'altimeter_dial':
-                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+                self.instruments[inst].setAltimeter(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'airspeed_dial':
-                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+                self.instruments[inst].setAirspeed(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'turn_coordinator':
-                self.insturments[inst].setHeading(self.data_items[db_item].value)
+                self.instruments[inst].setHeading(self.data_items[db_item].value)
 
-            self.insturments[inst].update()
+            self.instruments[inst].update()
             
 
     def grid_layout(self):
@@ -253,8 +253,8 @@ class Screen(QWidget):
             self.move_resize_inst(i,qRound(x),qRound(y),qRound(width),qRound(height))
             
     def move_resize_inst(self,inst,x,y,width,height):
-        self.insturments[inst].move(x,y)
-        self.insturments[inst].resize(width,height)
+        self.instruments[inst].move(x,y)
+        self.instruments[inst].resize(width,height)
 
 
     def resizeEvent(self, event):

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -154,6 +154,8 @@ class Screen(QWidget):
             #self.instruments[count].fontSize = i.get('options',{"font_size": 12}).get('font_size', 12)
             #self.instruments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
             #self.instruments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
+        elif i['type'] == 'altimeter_tape':
+            self.instruments[count] = altimeter.Altimeter_Tape(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'heading_display':
             self.instruments[count] = hsi.HeadingDisplay(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'horizontal_situation_indicator':
@@ -373,7 +375,7 @@ class Screen(QWidget):
                 if 'horizontal' in c['gang_type']:
                     total_gaps = (groups - 1) * (width * (2/100))
                 else: 
-                    total_gaps = (groups -1 ) * (height * (2/100))
+                    total_gaps = (groups -1 ) * (height * (6/100))
                 gap_size = 0
                 if groups > 1:
                     gap_size = total_gaps / ( groups - 1) 

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -183,15 +183,28 @@ class Screen(QWidget):
     def grid_layout(self):
         count = 1
         for i,c in self.insturment_config.items():
-            grid_width = self.width() / self.layout['columns']
-            grid_height = self.height() / self.layout['rows']
-            grid_x = grid_width * (c['column'] - 1) 
-            grid_y = grid_height * (c['row'] - 1) 
+            grid_width = self.width() / int(self.layout['columns'])
+            grid_height = self.height() / int(self.layout['rows'])
+            grid_x = grid_width * (int(c['column']) - 1) 
+            grid_y = grid_height * (int(c['row']) - 1) 
+
+            # Span columns to the right and rows down
+            if 'span' in c:
+                if 'rows' in c['span']:
+                    # spanning rows
+                    if c['span']['rows'] >= 2:
+                        grid_height = grid_height * int(c['span']['rows'])
+                if 'columns' in c['span']:
+                    #spanning columns
+                    if c['span']['columns'] >= 2:
+                        grid_width = grid_width * int(c['span']['columns'])
+
 
             width = grid_width
             height = grid_height
             x = grid_x
             y = grid_y
+
             if 'move' in c:
                 if 'shrink' in c['move']:
                     if (c['move'].get('shrink',0) < 99 ) and (c['move'].get('shrink',0) >= 0):
@@ -222,6 +235,7 @@ class Screen(QWidget):
                         x = grid_x + (( grid_width - width) / 2)
                     if not justified_vertical:
                         y = grid_y + (( grid_height - height) / 2) 
+            print(f"{x} {y} {width} {height}")
             self.move_resize_inst(i,qRound(x),qRound(y),qRound(width),qRound(height))
             
     def move_resize_inst(self,inst,x,y,width,height):

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -165,14 +165,14 @@ class Screen(QWidget):
         if i['type'] == 'airspeed_trend_tape':
             self.instruments[count] = vsi.AS_Trend_Tape(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'altimeter_dial':
-            self.instruments[count] = altimeter.Altimeter(self,data=self.data_items[db_items[0]])
+            self.instruments[count] = altimeter.Altimeter(self,data=self.data_items[db_items[0]].value)
         elif i['type'] == 'atitude_indicator':
             self.instruments[count] = ai.AI(self,data=self.get_data_dict2(count))
             #self.instruments[count].fontSize = i.get('options',{"font_size": 12}).get('font_size', 12)
             #self.instruments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
             #self.instruments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
         elif i['type'] == 'altimeter_tape':
-            self.instruments[count] = altimeter.Altimeter_Tape(self,data=self.data_items[db_items[0]])
+            self.instruments[count] = altimeter.Altimeter_Tape(self,data=self.data_items[db_items[0]].value)
         elif i['type'] == 'heading_display':
             self.instruments[count] = hsi.HeadingDisplay(self,data=self.data_items[db_items[0]])
         elif i['type'] == 'heading_tape':

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -25,6 +25,8 @@ from pyefis.instruments import airspeed
 from pyefis.instruments import altimeter
 from pyefis.instruments import vsi
 from pyefis.instruments import tc
+from pyefis.instruments import gauges
+from pyefis.instruments import misc
 
 import pyavtools.fix as fix
 from collections import defaultdict
@@ -65,8 +67,8 @@ class Screen(QWidget):
         self.data_distribution = defaultdict(list) # Keeps track of what instruments need sent what pieces of data
         self.instruments = dict() # Each instrument
         self.insturment_config = dict () # configuration for the instruments
-        self.data_signal_routing = defaultdict(lambda: defaultdict())  # Keeps track of the reverse maping for each instrument
-        self.data_item_signals_defined = defaultdict(lambda: defaultdict())  # Keeps track of the signals that have been setup for a given data item
+        self.data_signal_routing = defaultdict(lambda: defaultdict(list))  # Keeps track of the reverse maping for each instrument
+        self.data_item_signals_defined = defaultdict(lambda: defaultdict(dict))  # Keeps track of the signals that have been setup for a given data item
         # Setup instruments:
         count = 1
         for i in self.get_config_item('instruments'):
@@ -97,28 +99,33 @@ class Screen(QWidget):
             for item in db_items:
                     self.define_data(count,item,i['type'])
                     self.data_distribution[item].append(count)
-            # Process the type of gauge this is and create them
+            # Process the type of instrument this is and create them
             if i['type'] == 'airspeed_dial':
-                self.instruments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
+                self.instruments[count] = airspeed.Airspeed(self,data=self.data_items[db_items[0]])
             elif i['type'] == 'altimeter_dial':
-                self.instruments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
+                self.instruments[count] = altimeter.Altimeter(self,data=self.data_items[db_items[0]])
             elif i['type'] == 'atitude_indicator':
                 self.instruments[count] = ai.AI(self,data=self.get_data_dict(i['type']))
-                self.instruments[count].fontSize = i.get('options',{"font_size": 12}).get('font_size', 12)
-                self.instruments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
-                self.instruments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
+                #self.instruments[count].fontSize = i.get('options',{"font_size": 12}).get('font_size', 12)
+                #self.instruments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
+                #self.instruments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
             elif i['type'] == 'heading_display':
-                self.instruments[count] = hsi.HeadingDisplay(self,data=self.data_items[self.lookup_mapping('HEAD',i.get('mapping',dict()))])
-                self.instruments[count].font_size = self.instruments[count].font_size = i.get('options',{"font_size": 17}).get('font_size', 17)
+                self.instruments[count] = hsi.HeadingDisplay(self,data=self.data_items[db_items[0]])
             elif i['type'] == 'horizontal_situation_indicator':
                 self.instruments[count] = hsi.HSI(self,data=self.get_data_dict(i['type']))
-                self.instruments[count].gsi_enabled = i.get('options',{"gsi_enabled": True}).get('gsi_enabled', True)
-                self.instruments[count].cdi_enabled = i.get('options',{"cdi_enabled": True}).get('cdi_enabled', True)
             elif i['type'] == 'turn_coordinator':
                 self.instruments[count] = tc.TurnCoordinator(self,data=self.get_data_dict(i['type']))
             elif i['type'] == 'vsi_dial':
-                self.instruments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
+                self.instruments[count] = vsi.VSI_Dial(self,data=self.data_items[db_items[0]])
+            # Gauges
+            elif i['type'] == 'arc_gauge':
+                self.instruments[count] = gauges.ArcGauge(self,data=self.data_items[db_items[0]])
 
+            # Set options
+            if 'options' in i:
+                #loop over each option
+                for option,value in i['options'].items():
+                    setattr(self.instruments[count], option, value)
 
             count += 1
         #Place instruments:
@@ -168,6 +175,7 @@ class Screen(QWidget):
         if not item in self.data_items:
             print(f"db item: {item}")
             self.data_items[item] = fix.db.get_item(item)
+            print(self.data_items[item].dtype)
             if self.data_items[item].dtype == float:
                 self.data_items[item].valueChanged[float].connect(lambda valueChanged, key=item: self.data_modified(db_item=key) )
             if self.data_items[item].dtype == str:
@@ -179,24 +187,35 @@ class Screen(QWidget):
 
         # Not All gauges need all of the signals
         # We will only subscribe to the ones we need that have not already been subscripbed
-        if 'old' in self.what_signals(item_type):
+        if 'old' in self.what_signals(item_type) and not ('old' in self.data_item_signals_defined[item][count]):
             self.data_items[item].oldChanged[bool].connect(lambda oldChanged, key=item: self.data_redraw(db_item=key))
             self.data_item_signals_defined[item][count] = 'old'
-        if 'bad' in self.what_signals(item_type):
+            self.data_signal_routing[item]['old'].append(count)
+
+        if 'bad' in self.what_signals(item_type) and not ('bad' in self.data_item_signals_defined[item][count]):
             self.data_items[item].badChanged[bool].connect(lambda badChanged, key=item: self.data_redraw(db_item=key))
             self.data_item_signals_defined[item][count] = 'bad'
-        if 'fail' in self.what_signals(item_type):
+            self.data_signal_routing[item]['old'].append(count)
+
+        if 'fail' in self.what_signals(item_type) and not ('fail' in self.data_item_signals_defined[item][count]):
             self.data_items[item].failChanged[bool].connect(lambda failChanged, key=item: self.data_redraw(db_item=key))
             self.data_item_signals_defined[item][count] = 'fail'
-        if 'aux' in self.what_signals(item_type):
-            self.data_items[item].auxChanged[bool].connect(lambda failChanged, key=item: self.data_redraw(db_item=key))
+            self.data_signal_routing[item]['old'].append(count)
+
+        if 'aux' in self.what_signals(item_type) and not ('aux' in self.data_item_signals_defined[item][count]):
+            self.data_items[item].auxChanged.connect(lambda auxChanged, key=item: self.aux_data_modified(db_item=key))
             self.data_item_signals_defined[item][count] = 'aux'
-        if 'ann' in self.what_signals(item_type):
-            self.data_items[item].annunciateChanged[bool].connect(lambda failChanged, key=item: self.data_redraw(db_item=key))
+            self.data_signal_routing[item]['aux'].append(count)
+
+        if 'ann' in self.what_signals(item_type) and not ('ann' in self.data_item_signals_defined[item][count]):
+            self.data_items[item].annunciateChanged[bool].connect(lambda annunciateChanged, key=item: self.report_received(db_item=key))
             self.data_item_signals_defined[item][count] = 'ann'
-        if 'report' in self.what_signals(item_type):
-            self.data_items[item].reportReceived[bool].connect(lambda failChanged, key=item: self.data_redraw(db_item=key))
+            self.data_signal_routing[item]['report'].append(count)
+
+        if 'report' in self.what_signals(item_type) and not ('report' in self.data_item_signals_defined[item][count]):
+            self.data_items[item].reportReceived.connect(self.report_received)
             self.data_item_signals_defined[item][count] = 'report'
+            self.data_signal_routing[item]['report'].append(count)
 
     def what_signals(self, it):
         # Returns what signals are used for the instrument type
@@ -208,14 +227,27 @@ class Screen(QWidget):
 
     def data_modified(self,db_item):
         print(f"modified: {db_item}")
-        for inst in self.data_distribution[db_item]:
-            self.instruments[inst].setData(self.data_item_signals_defined[inst][db_item], self.data_items[db_item].value)
+        for inst in self.data_signal_routing[db_item]['old']:
+            self.instruments[inst].setData(db_item,self.data_items[db_item].value)
+
+    def aux_data_modified(self,db_item):
+        print(f"aux {db_item}")
+        for inst in self.data_signal_routing[db_item]['aux']:
+            self.instruments[inst].setAuxData(self.data_items[db_item].aux)
+
+    def report_received(self,db_item='t'):
+        print(f"report {db_item}")
+        for inst in self.data_signal_routing[db_item]['report']:
+            self.instruments[inst].setupGauge()#self.data_items[db_item].aux)
 
     def data_redraw(self,db_item):
         print(f"redraw: {db_item}")
-        for inst in self.data_distribution[db_item]:
+        for inst in self.data_signal_routing[db_item]['old']:
             self.instruments[inst].update()
-            
+            try:
+                self.instruments[inst].setupGauge()
+            except:
+                pass            
 
     def grid_layout(self):
         count = 1

--- a/pyefis/screens/sixpack.py
+++ b/pyefis/screens/sixpack.py
@@ -26,186 +26,52 @@ from pyefis.instruments import altimeter
 from pyefis.instruments import vsi
 from pyefis.instruments import tc
 
-import pyavtools.fix as fix
-from collections import defaultdict
 
 class Screen(QWidget):
-    def __init__(self, parent=None,config=None):
+    def __init__(self, parent=None):
         super(Screen, self).__init__(parent)
         self.parent = parent
         p = self.parent.palette()
+
         self.screenColor = (0, 0, 0)
         if self.screenColor:
             p.setColor(self.backgroundRole(), QColor(*self.screenColor))
             self.setPalette(p)
             self.setAutoFillBackground(True)
 
-        #self.airspeed = airspeed.Airspeed(self)
+        self.airspeed = airspeed.Airspeed(self)
 
-        #self.ai = ai.AI(self)
-        #self.ai.fontSize = 12
-        #self.ai.bankMarkSize = 7
-        #self.ai.pitchDegreesShown = 60
+        self.ai = ai.AI(self)
+        self.ai.fontSize = 12
+        self.ai.bankMarkSize = 7
+        self.ai.pitchDegreesShown = 60
 
-        #self.altimeter = altimeter.Altimeter(self)
+        self.altimeter = altimeter.Altimeter(self)
 
-        #self.tc = tc.TurnCoordinator(self)
+        self.tc = tc.TurnCoordinator(self)
 
         self.hsi = hsi.HSI(self, font_size=12, fgcolor=Qt.white)
         self.heading_disp = hsi.HeadingDisplay(self, font_size=17, fgcolor=Qt.white)
 
-        self.init= False
-        self.ai_mapping = dict()
-        self.tc_mapping = dict()
-
-    def init_screen(self):
-        self.layout = self.parent.get_config_item(self,'layout')
-        self.data_items = dict()
-        self.data_distribution = defaultdict(list)
-        self.insturments = dict()
-        self.insturment_config = dict ()
-        # Setup insturments:
-        count = 1
-        for i in self.get_config_item('insturments'):
-            self.insturment_config[count] = i
-            if type(i['db_items']) is list:
-                for item in i['db_items']:
-                    self.define_data(count,item)
-                    self.data_distribution[item].append(count)
-            else:
-                self.define_data(count,i['db_items'])
-                self.data_distribution[i['db_items']].append(count)
-            # Process the type of gauge this is
-            if i['type'] == 'vsi_dial':
-                self.insturments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
-            elif i['type'] == 'altimeter_dial':
-                self.insturments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
-            elif i['type'] == 'airspeed_dial':
-                self.insturments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
-            elif i['type'] == 'atitude_indicator':
-                self.ai_mapping['PITCH'] = self.lookup_mapping('PITCH',i.get('mapping',dict()))
-                self.ai_mapping['ROLL'] = self.lookup_mapping('ROLL',i.get('mapping',dict()))
-                self.ai_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
-                self.ai_mapping['TAS'] = self.lookup_mapping('TAS',i.get('mapping',dict()))
-
-                self.insturments[count] = ai.AI(self,data = {
-                    'PITCH': self.data_items[self.ai_mapping['PITCH']],
-                    'ROLL':  self.data_items[self.ai_mapping['ROLL']],
-                    'ALAT':  self.data_items[self.ai_mapping['ALAT']],
-                    'TAS':   self.data_items[self.ai_mapping['TAS']]
-                    }
-                )
-
-                self.insturments[count].fontSize = i.get('options',{"fontSize": 12}).get('fontSize', 12)
-                self.insturments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
-                self.insturments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
-            elif i['type'] == 'turn_coordinator':
-                self.tc_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
-                self.tc_mapping['ROT'] = self.lookup_mapping('ROT',i.get('mapping',dict()))
-
-                self.insturments[count] = tc.TurnCoordinator(self,data ={
-                    'ALAT': self.data_items[self.tc_mapping['ALAT']],
-                    'ROT': self.data_items[self.tc_mapping['ROT']],
-                    }
-                )
-
-            count += 1
-        #Place insturments:
-        if self.layout['type'] == 'grid':
-            self.grid_layout()
-        self.init = True
-
-    def lookup_mapping(self,item,mapping=dict()):
-          return mapping.get(item,item)
-
-    def define_data(self,count,item):
-        if not item in self.data_items:
-            print(f"db item: {item}")
-            self.data_items[item] = fix.db.get_item(item)
-            self.data_items[item].valueChanged[float].connect(lambda valueChanged, key=item: self.data_modified(db_item=key) )
-            self.data_items[item].valueChanged[str].connect(lambda valueChanged, key=item: self.data_modified(db_item=key))
-            self.data_items[item].valueChanged[bool].connect(lambda valueChanged, key=item: self.data_modified(db_item=key))
-            self.data_items[item].oldChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
-            self.data_items[item].badChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
-            self.data_items[item].failChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
-
-
-    def data_modified(self,db_item):
-        print(f"modified: {db_item}")
-        for inst in self.data_distribution[db_item]:
-            if self.insturment_config[inst]['type'] == 'vsi_dial':
-                self.insturments[inst].setROC(self.data_items[db_item].value)
-            elif self.insturment_config[inst]['type'] == 'altimeter_dial':
-                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
-            elif self.insturment_config[inst]['type'] == 'airspeed_dial':
-                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
-            elif self.insturment_config[inst]['type'] == 'atitude_indicator':
-                self.insturments[inst].setPitchAngle(self.data_items[self.ai_mapping['PITCH']].value)
-                self.insturments[inst].setRollAngle(self.data_items[self.ai_mapping['ROLL']].value)
-                self.insturments[inst].setLateralAcceleration(self.data_items[self.ai_mapping['ALAT']].value)
-                self.insturments[inst].setTrueAirspeed(self.data_items[self.ai_mapping['TAS']].value)
-            elif self.insturment_config[inst]['type'] == 'turn_coordinator':
-                self.insturments[inst].setLatAcc(self.data_items[self.tc_mapping['ALAT']].value)
-                self.insturments[inst].setROT(self.data_items[self.tc_mapping['ROT']].value)
-
-
-
-
-    def data_redraw(self,db_item):
-        print(f"redraw: {db_item}")
-        for inst in self.data_distribution[db_item]:
-            if self.insturment_config[inst]['type'] == 'vsi_dial':
-                self.insturments[inst].setROC(self.data_items[db_item].value)
-                self.insturments[inst].update()
-            elif self.insturment_config[inst]['type'] == 'altimeter_dial':
-                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
-                self.insturments[inst].update()
-            elif self.insturment_config[inst]['type'] == 'airspeed_dial':
-                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
-                self.insturments[inst].update()
-
-
-    def grid_layout(self):
-        count = 1
-        for i,c in self.insturment_config.items():
-            width = qRound(self.width() / self.layout['columns'])
-            height = qRound(self.height() / self.layout['rows'])
-            x = qRound(width * (c['column'] - 1) )
-            y = qRound(height * (c['row'] - 1) )
-            print(f"width={width} height={height} x={x} y={y}")
-            self.move_resize_inst(i,x,y,width,height)
-            
-    def move_resize_inst(self,inst,x,y,width,height):
-        self.insturments[inst].move(x,y)
-        self.insturments[inst].resize(width,height)
-        #self.insturments[inst].show()
-
-    def vsi_dial(self,count=None,db=None):
-        self.insturments[count] = vsi.VSI_Dial(self,data=db)
-        #self.db.valueChanged[float].connect(self.insturments[count].setROC)
-        #self.db.oldChanged[bool].connect(self.insturments[count].repaint)
-        #self.db.badChanged[bool].connect(self.insturments[count].repaint)
-        #self.db.failChanged[bool].connect(self.insturments[count].repaint)
+        self.vsi = vsi.VSI_Dial(self)
 
     def resizeEvent(self, event):
-        if not self.init:
-            self.init_screen()
         menu_offset = 30
         instWidth = qRound(self.width()/3)
         instHeight = qRound((self.height()-menu_offset)/2)
         diameter=min(instWidth,instHeight)
 
-        #self.airspeed.move(0,menu_offset)
-        #self.airspeed.resize(instWidth,instHeight)
+        self.airspeed.move(0,menu_offset)
+        self.airspeed.resize(instWidth,instHeight)
 
-        #self.ai.move(instWidth, 0 + menu_offset)
-        #self.ai.resize(instWidth, instHeight)
+        self.ai.move(instWidth, 0 + menu_offset)
+        self.ai.resize(instWidth, instHeight)
 
-        #self.altimeter.move(instWidth*2, 0 + menu_offset)
-        #self.altimeter.resize(instWidth,instHeight)
+        self.altimeter.move(instWidth*2, 0 + menu_offset)
+        self.altimeter.resize(instWidth,instHeight)
 
-        #self.tc.move(0, instHeight + menu_offset)
-        #self.tc.resize(instWidth, instHeight)
+        self.tc.move(0, instHeight + menu_offset)
+        self.tc.resize(instWidth, instHeight)
 
         hdh = self.heading_disp.height()
         hdw = self.heading_disp.width()
@@ -215,9 +81,8 @@ class Screen(QWidget):
         self.hsi.resize(hsi_diameter,hsi_diameter)
         self.heading_disp.move(qRound(instWidth*1.5-hdw/2), qRound(instHeight + menu_offset+10))
 
-        #self.vsi.move(instWidth * 2, instHeight + menu_offset)
-        #self.vsi.resize(instWidth, instHeight)
-        if self.layout['type'] == 'grid':
-            self.grid_layout()
+        self.vsi.move(instWidth * 2, instHeight + menu_offset)
+        self.vsi.resize(instWidth, instHeight)
+
     def get_config_item(self, key):
         return self.parent.get_config_item(self, key)

--- a/pyefis/screens/sixpack.py
+++ b/pyefis/screens/sixpack.py
@@ -42,10 +42,10 @@ class Screen(QWidget):
 
         #self.airspeed = airspeed.Airspeed(self)
 
-        self.ai = ai.AI(self)
-        self.ai.fontSize = 12
-        self.ai.bankMarkSize = 7
-        self.ai.pitchDegreesShown = 60
+        #self.ai = ai.AI(self)
+        #self.ai.fontSize = 12
+        #self.ai.bankMarkSize = 7
+        #self.ai.pitchDegreesShown = 60
 
         #self.altimeter = altimeter.Altimeter(self)
 
@@ -55,7 +55,8 @@ class Screen(QWidget):
         self.heading_disp = hsi.HeadingDisplay(self, font_size=17, fgcolor=Qt.white)
 
         self.init= False
-        
+        self.ai_mapping = dict()
+
     def init_screen(self):
         self.layout = self.parent.get_config_item(self,'layout')
         self.data_items = dict()
@@ -80,6 +81,23 @@ class Screen(QWidget):
                 self.insturments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
             elif i['type'] == 'airspeed_dial':
                 self.insturments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
+            elif i['type'] == 'atitude_indicator':
+                self.ai_mapping['PITCH'] = self.lookup_mapping('PITCH',i.get('mapping',dict()))
+                self.ai_mapping['ROLL'] = self.lookup_mapping('ROLL',i.get('mapping',dict()))
+                self.ai_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
+                self.ai_mapping['TAS'] = self.lookup_mapping('TAS',i.get('mapping',dict()))
+
+                self.insturments[count] = ai.AI(self,data = {
+                    'PITCH': self.data_items[self.ai_mapping['PITCH']],
+                    'ROLL':  self.data_items[self.ai_mapping['ROLL']],
+                    'ALAT':  self.data_items[self.ai_mapping['ALAT']],
+                    'TAS':   self.data_items[self.ai_mapping['TAS']]
+                    }
+                )
+
+                self.insturments[count].fontSize = i.get('options',{"fontSize": 12}).get('fontSize', 12)
+                self.insturments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
+                self.insturments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
 
             count += 1
 
@@ -112,6 +130,12 @@ class Screen(QWidget):
                 self.insturments[inst].setAltimeter(self.data_items[db_item].value)
             elif self.insturment_config[inst]['type'] == 'airspeed_dial':
                 self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'atitude_indicator':
+                self.insturments[inst].setPitchAngle(self.data_items[self.ai_mapping['PITCH']].value)
+                self.insturments[inst].setRollAngle(self.data_items[self.ai_mapping['ROLL']].value)
+                self.insturments[inst].setLateralAcceleration(self.data_items[self.ai_mapping['ALAT']].value)
+                self.insturments[inst].setTrueAirspeed(self.data_items[self.ai_mapping['TAS']].value)
+
 
 
     def data_redraw(self,db_item):
@@ -161,8 +185,8 @@ class Screen(QWidget):
         #self.airspeed.move(0,menu_offset)
         #self.airspeed.resize(instWidth,instHeight)
 
-        self.ai.move(instWidth, 0 + menu_offset)
-        self.ai.resize(instWidth, instHeight)
+        #self.ai.move(instWidth, 0 + menu_offset)
+        #self.ai.resize(instWidth, instHeight)
 
         #self.altimeter.move(instWidth*2, 0 + menu_offset)
         #self.altimeter.resize(instWidth,instHeight)

--- a/pyefis/screens/sixpack.py
+++ b/pyefis/screens/sixpack.py
@@ -40,7 +40,7 @@ class Screen(QWidget):
             self.setPalette(p)
             self.setAutoFillBackground(True)
 
-        self.airspeed = airspeed.Airspeed(self)
+        #self.airspeed = airspeed.Airspeed(self)
 
         self.ai = ai.AI(self)
         self.ai.fontSize = 12
@@ -78,6 +78,8 @@ class Screen(QWidget):
                 self.insturments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
             elif i['type'] == 'altimeter_dial':
                 self.insturments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
+            elif i['type'] == 'airspeed_dial':
+                self.insturments[count] = airspeed.Airspeed(self,data=self.data_items[self.lookup_mapping('IAS',i.get('mapping',dict()))])
 
             count += 1
 
@@ -106,9 +108,11 @@ class Screen(QWidget):
         for inst in self.data_distribution[db_item]:
             if self.insturment_config[inst]['type'] == 'vsi_dial':
                 self.insturments[inst].setROC(self.data_items[db_item].value)
-            if self.insturment_config[inst]['type'] == 'altimeter_dial':
-                print("modified")
+            elif self.insturment_config[inst]['type'] == 'altimeter_dial':
                 self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+            elif self.insturment_config[inst]['type'] == 'airspeed_dial':
+                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+
 
     def data_redraw(self,db_item):
         print(f"redraw: {db_item}")
@@ -119,6 +123,10 @@ class Screen(QWidget):
             elif self.insturment_config[inst]['type'] == 'altimeter_dial':
                 self.insturments[inst].setAltimeter(self.data_items[db_item].value)
                 self.insturments[inst].update()
+            elif self.insturment_config[inst]['type'] == 'airspeed_dial':
+                self.insturments[inst].setAirspeed(self.data_items[db_item].value)
+                self.insturments[inst].update()
+
 
     def grid_layout(self):
         count = 1
@@ -150,8 +158,8 @@ class Screen(QWidget):
         instHeight = qRound((self.height()-menu_offset)/2)
         diameter=min(instWidth,instHeight)
 
-        self.airspeed.move(0,menu_offset)
-        self.airspeed.resize(instWidth,instHeight)
+        #self.airspeed.move(0,menu_offset)
+        #self.airspeed.resize(instWidth,instHeight)
 
         self.ai.move(instWidth, 0 + menu_offset)
         self.ai.resize(instWidth, instHeight)

--- a/pyefis/screens/sixpack.py
+++ b/pyefis/screens/sixpack.py
@@ -26,13 +26,14 @@ from pyefis.instruments import altimeter
 from pyefis.instruments import vsi
 from pyefis.instruments import tc
 
+import pyavtools.fix as fix
+from collections import defaultdict
 
 class Screen(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None,config=None):
         super(Screen, self).__init__(parent)
         self.parent = parent
         p = self.parent.palette()
-
         self.screenColor = (0, 0, 0)
         if self.screenColor:
             p.setColor(self.backgroundRole(), QColor(*self.screenColor))
@@ -46,16 +47,104 @@ class Screen(QWidget):
         self.ai.bankMarkSize = 7
         self.ai.pitchDegreesShown = 60
 
-        self.altimeter = altimeter.Altimeter(self)
+        #self.altimeter = altimeter.Altimeter(self)
 
         self.tc = tc.TurnCoordinator(self)
 
         self.hsi = hsi.HSI(self, font_size=12, fgcolor=Qt.white)
         self.heading_disp = hsi.HeadingDisplay(self, font_size=17, fgcolor=Qt.white)
 
-        self.vsi = vsi.VSI_Dial(self)
+        self.init= False
+        
+    def init_screen(self):
+        self.layout = self.parent.get_config_item(self,'layout')
+        self.data_items = dict()
+        self.data_distribution = defaultdict(list)
+        self.insturments = dict()
+        self.insturment_config = dict ()
+        # Setup insturments:
+        count = 1
+        for i in self.get_config_item('insturments'):
+            self.insturment_config[count] = i
+            if type(i['db_items']) is list:
+                for item in i['db_items']:
+                    self.define_data(count,item)
+                    self.data_distribution[item].append(count)
+            else:
+                self.define_data(count,i['db_items'])
+                self.data_distribution[i['db_items']].append(count)
+            # Process the type of gauge this is
+            if i['type'] == 'vsi_dial':
+                self.insturments[count] = vsi.VSI_Dial(self,data=self.data_items[self.lookup_mapping('VS',i.get('mapping',dict()))])
+            elif i['type'] == 'altimeter_dial':
+                self.insturments[count] = altimeter.Altimeter(self,data=self.data_items[self.lookup_mapping('ALT',i.get('mapping',dict()))])
+
+            count += 1
+
+        #Place insturments:
+        if self.layout['type'] == 'grid':
+            self.grid_layout()
+        self.init = True
+
+    def lookup_mapping(self,item,mapping=dict()):
+          return mapping.get(item,item)
+
+    def define_data(self,count,item):
+        if not item in self.data_items:
+            print(f"db item: {item}")
+            self.data_items[item] = fix.db.get_item(item)
+            self.data_items[item].valueChanged[float].connect(lambda valueChanged, key=item: self.data_modified(db_item=key) )
+            self.data_items[item].valueChanged[str].connect(lambda valueChanged, key=item: self.data_modified(db_item=key))
+            self.data_items[item].valueChanged[bool].connect(lambda valueChanged, key=item: self.data_modified(db_item=key))
+            self.data_items[item].oldChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
+            self.data_items[item].badChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
+            self.data_items[item].failChanged[bool].connect(lambda valueChanged, key=item: self.data_redraw(db_item=key))
+
+
+    def data_modified(self,db_item):
+        print(f"modified: {db_item}")
+        for inst in self.data_distribution[db_item]:
+            if self.insturment_config[inst]['type'] == 'vsi_dial':
+                self.insturments[inst].setROC(self.data_items[db_item].value)
+            if self.insturment_config[inst]['type'] == 'altimeter_dial':
+                print("modified")
+                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+
+    def data_redraw(self,db_item):
+        print(f"redraw: {db_item}")
+        for inst in self.data_distribution[db_item]:
+            if self.insturment_config[inst]['type'] == 'vsi_dial':
+                self.insturments[inst].setROC(self.data_items[db_item].value)
+                self.insturments[inst].update()
+            elif self.insturment_config[inst]['type'] == 'altimeter_dial':
+                self.insturments[inst].setAltimeter(self.data_items[db_item].value)
+                self.insturments[inst].update()
+
+    def grid_layout(self):
+        count = 1
+        for i,c in self.insturment_config.items():
+            width = qRound(self.width() / self.layout['columns'])
+            height = qRound(self.height() / self.layout['rows'])
+            x = qRound(width * (c['column'] - 1) )
+            y = qRound(height * (c['row'] - 1) )
+            print(f"width={width} height={height} x={x} y={y}")
+            self.move_resize_inst(i,x,y,width,height)
+            
+    def move_resize_inst(self,inst,x,y,width,height):
+        self.insturments[inst].move(x,y)
+        self.insturments[inst].resize(width,height)
+        #self.insturments[inst].show()
+
+    def vsi_dial(self,count=None,db=None):
+        self.insturments[count] = vsi.VSI_Dial(self,data=db)
+        #self.db.valueChanged[float].connect(self.insturments[count].setROC)
+        #self.db.oldChanged[bool].connect(self.insturments[count].repaint)
+        #self.db.badChanged[bool].connect(self.insturments[count].repaint)
+        #self.db.failChanged[bool].connect(self.insturments[count].repaint)
 
     def resizeEvent(self, event):
+        if not self.init:
+            self.init_screen()
         menu_offset = 30
         instWidth = qRound(self.width()/3)
         instHeight = qRound((self.height()-menu_offset)/2)
@@ -67,8 +156,8 @@ class Screen(QWidget):
         self.ai.move(instWidth, 0 + menu_offset)
         self.ai.resize(instWidth, instHeight)
 
-        self.altimeter.move(instWidth*2, 0 + menu_offset)
-        self.altimeter.resize(instWidth,instHeight)
+        #self.altimeter.move(instWidth*2, 0 + menu_offset)
+        #self.altimeter.resize(instWidth,instHeight)
 
         self.tc.move(0, instHeight + menu_offset)
         self.tc.resize(instWidth, instHeight)
@@ -81,8 +170,9 @@ class Screen(QWidget):
         self.hsi.resize(hsi_diameter,hsi_diameter)
         self.heading_disp.move(qRound(instWidth*1.5-hdw/2), qRound(instHeight + menu_offset+10))
 
-        self.vsi.move(instWidth * 2, instHeight + menu_offset)
-        self.vsi.resize(instWidth, instHeight)
-
+        #self.vsi.move(instWidth * 2, instHeight + menu_offset)
+        #self.vsi.resize(instWidth, instHeight)
+        if self.layout['type'] == 'grid':
+            self.grid_layout()
     def get_config_item(self, key):
         return self.parent.get_config_item(self, key)

--- a/pyefis/screens/sixpack.py
+++ b/pyefis/screens/sixpack.py
@@ -49,13 +49,14 @@ class Screen(QWidget):
 
         #self.altimeter = altimeter.Altimeter(self)
 
-        self.tc = tc.TurnCoordinator(self)
+        #self.tc = tc.TurnCoordinator(self)
 
         self.hsi = hsi.HSI(self, font_size=12, fgcolor=Qt.white)
         self.heading_disp = hsi.HeadingDisplay(self, font_size=17, fgcolor=Qt.white)
 
         self.init= False
         self.ai_mapping = dict()
+        self.tc_mapping = dict()
 
     def init_screen(self):
         self.layout = self.parent.get_config_item(self,'layout')
@@ -98,9 +99,17 @@ class Screen(QWidget):
                 self.insturments[count].fontSize = i.get('options',{"fontSize": 12}).get('fontSize', 12)
                 self.insturments[count].bankMarkSize = i.get('options',{'bankMarkSize': 7}).get('bankMarkSize', 7)
                 self.insturments[count].pitchDegreesShown = i.get('options',{'pitchDegreesShown': 60}).get('pitchDegreesShown', 60)
+            elif i['type'] == 'turn_coordinator':
+                self.tc_mapping['ALAT'] = self.lookup_mapping('ALAT',i.get('mapping',dict()))
+                self.tc_mapping['ROT'] = self.lookup_mapping('ROT',i.get('mapping',dict()))
+
+                self.insturments[count] = tc.TurnCoordinator(self,data ={
+                    'ALAT': self.data_items[self.tc_mapping['ALAT']],
+                    'ROT': self.data_items[self.tc_mapping['ROT']],
+                    }
+                )
 
             count += 1
-
         #Place insturments:
         if self.layout['type'] == 'grid':
             self.grid_layout()
@@ -135,6 +144,10 @@ class Screen(QWidget):
                 self.insturments[inst].setRollAngle(self.data_items[self.ai_mapping['ROLL']].value)
                 self.insturments[inst].setLateralAcceleration(self.data_items[self.ai_mapping['ALAT']].value)
                 self.insturments[inst].setTrueAirspeed(self.data_items[self.ai_mapping['TAS']].value)
+            elif self.insturment_config[inst]['type'] == 'turn_coordinator':
+                self.insturments[inst].setLatAcc(self.data_items[self.tc_mapping['ALAT']].value)
+                self.insturments[inst].setROT(self.data_items[self.tc_mapping['ROT']].value)
+
 
 
 
@@ -191,8 +204,8 @@ class Screen(QWidget):
         #self.altimeter.move(instWidth*2, 0 + menu_offset)
         #self.altimeter.resize(instWidth,instHeight)
 
-        self.tc.move(0, instHeight + menu_offset)
-        self.tc.resize(instWidth, instHeight)
+        #self.tc.move(0, instHeight + menu_offset)
+        #self.tc.resize(instWidth, instHeight)
 
         hdh = self.heading_disp.height()
         hdw = self.heading_disp.width()


### PR DESCRIPTION
This is related to #91 

I wanted to see what it would take to decouple the the FIX code from the widgets  like you mentioned.
Then I got carried away and built a screen builder that allows you to place instruments on the screen purely with configuration files.

The configuration in this pull request has two sixpack screens, the screenbuilder one ( default ) and if you press back you will get the original.
This was done to also prove that the changes made to the widgets allow them to work with the old way of making screens and with the screen builder way.
So far all the gauges used in sixpack have been updated to work with screenbuilder, still have work to do on many other  gauges.

Within the screen builder it handles the data events more efficiently too.
Each data item only has a single signal and the screenbuilder then calls the update functions of the widgets that use that data item.
Longer term I want to move the data up yet another layer so we only have one signal for each data item and only update the items on the active screen that use that piece of data.

If you will be willing to merge this and like the direction I will keep working on this.
If you have some suggestions or things I should change let me know.