### PR TITLE
Relative includes

### DIFF
--- a/docs/screenbuilder.md
+++ b/docs/screenbuilder.md
@@ -359,6 +359,9 @@ instruments:
 All of the instruments are defined the same as in the main.yaml
 Currently you cannot use includes inside of includes.
 
+##### Include relative #####
+When defiing includes you can assume that each instrument starts at 0.
+Then within the main config you can define `relative: true` along with row and column and the instruments in the include will be rendered starting at the defined row and column.  This allows you to define something complex such as AHRS with heading and such then reuse that definition on various screens and different locations on the screen.
 
 
 # Instrument List #

--- a/pyefis/config/includes/basic_arcs.yaml
+++ b/pyefis/config/includes/basic_arcs.yaml
@@ -1,0 +1,33 @@
+instruments:
+  - type: ganged_arc_gauge
+    gang_type: vertical
+    row: 0
+    column: 0
+    span:
+      rows: 110
+      columns: 50
+    groups:
+      - name: Engine
+        common_options:
+          nameLocation: right
+          decimalPlaces: 0
+        instruments:
+          -
+            options:
+              name: RPM
+              dbkey: TACH1
+          -
+            options:
+              name: Coolant
+              temperature: true
+              dbkey: H2OT1
+              showUnits: true
+          -
+            options:
+              name: Oil Press
+              dbkey: OILP1
+          -
+            options:
+              name: Fuel Total
+              dbkey: FUELQT
+

--- a/pyefis/config/includes/side-buttons.yaml
+++ b/pyefis/config/includes/side-buttons.yaml
@@ -6,7 +6,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/screen-ems-pfd.yaml
+      config: buttons/screen-ems-pfd.yaml
   - type: button
     row: 2
     column: 0
@@ -14,7 +14,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/screen-ems-pfd.yaml
+      config: buttons/screen-ems-pfd.yaml
   - type: button
     row: 20
     column: 376
@@ -22,7 +22,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/screen-map-pfd.yaml
+      config: buttons/screen-map-pfd.yaml
   - type: button
     row: 20
     column: 0
@@ -30,7 +30,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/screen-map-pfd.yaml
+      config: buttons/screen-map-pfd.yaml
   - type: button
     row: 38
     column: 376
@@ -38,7 +38,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/units.yaml
+      config: buttons/units.yaml
   - type: button
     row: 38
     column: 0
@@ -46,7 +46,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/units.yaml
+      config: buttons/units.yaml
   - type: button
     row: 56
     column: 376
@@ -54,7 +54,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/auto-pilot-adjust.yaml
+      config: buttons/auto-pilot-adjust.yaml
   - type: button
     row: 56
     column: 0
@@ -62,7 +62,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/auto-pilot-adjust.yaml
+      config: buttons/auto-pilot-adjust.yaml
   - type: button
     row: 74
     column: 376
@@ -70,7 +70,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/auto-pilot-heading-hold.yaml
+      config: buttons/auto-pilot-heading-hold.yaml
   - type: button
     row: 74
     column: 0
@@ -78,7 +78,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/auto-pilot-heading-hold.yaml
+      config: buttons/auto-pilot-heading-hold.yaml
   - type: button
     row: 92
     column: 376
@@ -86,7 +86,7 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/auto-pilot-flight-plan.yaml
+      config: buttons/auto-pilot-flight-plan.yaml
   - type: button
     row: 92
     column: 0
@@ -94,4 +94,4 @@ instruments:
       rows: 15
       columns: 24
     options:
-      config: config/buttons/auto-pilot-flight-plan.yaml
+      config: buttons/auto-pilot-flight-plan.yaml

--- a/pyefis/config/screenbuilder.yaml
+++ b/pyefis/config/screenbuilder.yaml
@@ -171,7 +171,7 @@ screens:
       rows: 110
       columns: 400
     instruments:
-      - type: include,config/includes/side-buttons.yaml
+      - type: include,includes/side-buttons.yaml
       - type: ganged_arc_gauge
         gang_type: vertical
         row: 0
@@ -213,7 +213,7 @@ screens:
           columns: 300
         options:
           socket: pyefis-waydroid-1
-          ini: config/weston.ini
+          ini: weston.ini
           command: waydroid
           args:
             - show-full-ui
@@ -229,7 +229,7 @@ screens:
       rows: 110
       columns: 400
     instruments:
-      - type: include,config/includes/side-buttons.yaml
+      - type: include,includes/side-buttons.yaml
 #      - type: static_text
 #        row: 56
 #        column: 1
@@ -382,7 +382,7 @@ screens:
           rows: 10
           columns: 10
         options:
-          config: config/buttons/baro-down-invisible.yaml
+          config: buttons/baro-down-invisible.yaml
       - type: button
         row: 80
         column: 238
@@ -390,7 +390,7 @@ screens:
           rows: 10
           columns: 10
         options:
-          config: config/buttons/baro-up-invisible.yaml          
+          config: buttons/baro-up-invisible.yaml          
       - type: static_text
         row: 95
         column: 224
@@ -465,7 +465,7 @@ screens:
           rows: 14
           columns: 10
         options:
-          config: config/buttons/trim-up-invisible.yaml
+          config: buttons/trim-up-invisible.yaml
       - type: button
         row: 85
         column: 75
@@ -473,7 +473,7 @@ screens:
           rows: 10
           columns: 10
         options:
-          config: config/buttons/trim-center-invisible.yaml
+          config: buttons/trim-center-invisible.yaml
       - type: button
         row: 95
         column: 75
@@ -481,7 +481,7 @@ screens:
           rows: 15
           columns: 10
         options:
-          config: config/buttons/trim-down-invisible.yaml
+          config: buttons/trim-down-invisible.yaml
       - type: horizontal_bar_gauge
         row: 100
         column: 86
@@ -513,7 +513,7 @@ screens:
           rows: 10
           columns: 15
         options:
-          config: config/buttons/trim-yaw-left-invisible.yaml
+          config: buttons/trim-yaw-left-invisible.yaml
       - type: button
         row: 100
         column: 100
@@ -521,7 +521,7 @@ screens:
           rows: 10
           columns: 10
         options:
-          config: config/buttons/trim-yaw-center-invisible.yaml
+          config: buttons/trim-yaw-center-invisible.yaml
       - type: button
         row: 100
         column: 110
@@ -529,7 +529,7 @@ screens:
           rows: 10
           columns: 15
         options:
-          config: config/buttons/trim-yaw-right-invisible.yaml
+          config: buttons/trim-yaw-right-invisible.yaml
       - type: button
         row: 90
         column: 85
@@ -537,7 +537,7 @@ screens:
           rows: 10
           columns: 15
         options:
-          config: config/buttons/trim-roll-left-invisible.yaml
+          config: buttons/trim-roll-left-invisible.yaml
       - type: button
         row: 90
         column: 100
@@ -545,7 +545,7 @@ screens:
           rows: 10
           columns: 10
         options:
-          config: config/buttons/trim-roll-center-invisible.yaml
+          config: buttons/trim-roll-center-invisible.yaml
       - type: button
         row: 90
         column: 110
@@ -553,7 +553,7 @@ screens:
           rows: 10
           columns: 15
         options:
-          config: config/buttons/trim-roll-right-invisible.yaml
+          config: buttons/trim-roll-right-invisible.yaml
 
 #      - type: ganged_arc_gauge
 #        gang_type: vertical
@@ -707,7 +707,7 @@ screens:
       columns: 400
       draw_grid: false #true
     instruments:
-      - type: include,config/includes/side-buttons.yaml
+      - type: include,includes/side-buttons.yaml
       - type: ganged_button
         disabled: true
         gang_type: horizontal
@@ -725,16 +725,16 @@ screens:
             instruments:
               -
                 options:
-                  config: config/buttons/egt-Normalize.yaml
+                  config: buttons/egt-Normalize.yaml
               -
                 options:
-                  config: config/buttons/egt-Lean.yaml
+                  config: buttons/egt-Lean.yaml
               -
                 options:
-                  config: config/buttons/egt-Peak.yaml
+                  config: buttons/egt-Peak.yaml
               -
                 options:
-                  config: config/buttons/egt-reset-peak.yaml
+                  config: buttons/egt-reset-peak.yaml
       -
         type: ganged_vertical_bar_gauge
         gang_type: horizontal

--- a/pyefis/config/screenbuilder.yaml
+++ b/pyefis/config/screenbuilder.yaml
@@ -172,38 +172,10 @@ screens:
       columns: 400
     instruments:
       - type: include,includes/side-buttons.yaml
-      - type: ganged_arc_gauge
-        gang_type: vertical
+      - type: include,includes/basic_arcs.yaml
+        relative: true
         row: 0
         column: 25
-        span:
-          rows: 110
-          columns: 50
-        groups:
-          - name: Engine
-            common_options:
-              nameLocation: right
-              decimalPlaces: 0
-            instruments:
-              -
-                options:
-                  name: RPM
-                  dbkey: TACH1
-              -
-                options:
-                  name: Coolant
-                  temperature: true
-                  dbkey: H2OT1
-                  showUnits: true
-              -
-                options:
-                  name: Oil Press
-                  dbkey: OILP1
-              -
-                options:
-                  name: Fuel Total
-                  dbkey: FUELQT
-
       - type: weston
         disabled: true
         row: 0
@@ -574,44 +546,10 @@ screens:
 #                  temperature: true
 #                  dbkey: CHTMAX1
 
-      - type: ganged_arc_gauge
-        gang_type: vertical
+      - type: include,includes/basic_arcs.yaml
+        relative: true
         row: 0
         column: 25
-        span:
-          rows: 110
-          columns: 50
-        groups:
-          - name: Engine
-            common_options:
-              nameLocation: right
-              decimalPlaces: 0
-            instruments:
-              -
-                options:
-                  name: RPM
-                  dbkey: TACH1
-              -
-                options:
-                  name: Coolant
-                  temperature: true
-                  dbkey: H2OT1
-                  showUnits: true
-#              -
-#                options:
-#                  name: Avg EGT
-#                  temperature: true
-#                  dbkey: EGTAVG1
-              -
-                options:
-                  name: Oil Press
-                  dbkey: OILP1
-              -
-                options:
-                  name: Oil Temp
-                  dbkey: OILT1
-                  temperature: true
-                  showUnits: true
       - type: ganged_arc_gauge
         gang_type: vertical
         row: 0

--- a/pyefis/gui.py
+++ b/pyefis/gui.py
@@ -59,10 +59,10 @@ class Main(QMainWindow):
     windowClose = pyqtSignal(QEvent)
     #change_asd_mode = pyqtSignal(QEvent)
 
-    def __init__(self, config, parent=None):
+    def __init__(self, config, config_path, parent=None):
         super(Main, self).__init__(parent)
 
-        self.path = os.path.dirname(__file__)
+        self.config_path = config_path
         self.screenWidth = int(config["main"]["screenWidth"])
         self.screenHeight = int(config["main"]["screenHeight"])
         self.screenColor = config["main"]["screenColor"]
@@ -173,7 +173,7 @@ def setDefaultScreen(s):
     return found
 
 
-def initialize(config):
+def initialize(config,config_path):
     global mainWindow
     global log
     log = logging.getLogger(__name__)
@@ -196,7 +196,7 @@ def initialize(config):
 
     setDefaultScreen(d)
 
-    mainWindow = Main(config)
+    mainWindow = Main(config,config_path)
     hmi.actions.showNextScreen.connect(mainWindow.showNextScreen)
     hmi.actions.showPrevScreen.connect(mainWindow.showPrevScreen)
     hmi.actions.showScreen.connect(mainWindow.showScreen)

--- a/pyefis/main.py
+++ b/pyefis/main.py
@@ -159,7 +159,7 @@ def main():
         fms = importlib.import_module ("FixIntf")
         fms.start(config["FMS"]["aircraft_config"])
 
-    gui.initialize(config)
+    gui.initialize(config,config_path)
     if "keybindings" in config:
         hmi.keys.initialize(gui.mainWindow, config["keybindings"])
     hooks.initialize(config['hooks'])

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -95,14 +95,22 @@ class Screen(QWidget):
         for i in self.get_config_item('instruments'):
             if 'disabled' in i and i['disabled'] == True:
                 continue
+            relative = False
             if 'include,' in i['type']:
                 # Here we will include some instruments defined in another file
                 args = i['type'].split(',')
+                relative = i.get('relative', False)
+                relative_x = i.get('row', 0)
+                relative_y = i.get('column', 0)
+                
                 iconfig = yaml.load(open(os.path.join(self.parent.config_path,args[1])), Loader=yaml.SafeLoader)
                 insts = iconfig['instruments']
             else:
                 insts = [i]
             for inst in insts:        
+                if relative:
+                  inst['row'] = inst['row'] + relative_x
+                  inst['column'] = inst['column'] + relative_y
                 if 'ganged' in inst['type']:
                     #ganged instrument
                     if 'gang_type' not in inst:

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -98,7 +98,7 @@ class Screen(QWidget):
             if 'include,' in i['type']:
                 # Here we will include some instruments defined in another file
                 args = i['type'].split(',')
-                iconfig = yaml.load(open(os.path.join(self.parent.path,args[1])), Loader=yaml.SafeLoader)
+                iconfig = yaml.load(open(os.path.join(self.parent.config_path,args[1])), Loader=yaml.SafeLoader)
                 insts = iconfig['instruments']
             else:
                 insts = [i]
@@ -145,7 +145,7 @@ class Screen(QWidget):
 
         # Process the type of instrument this is and create them
         if i['type'] == 'weston':
-            self.instruments[count] = weston.Weston(self,socket=i['options']['socket'],ini=os.path.join(self.parent.path,i['options']['ini']),command=i['options']['command'],args=i['options']['args'])
+            self.instruments[count] = weston.Weston(self,socket=i['options']['socket'],ini=os.path.join(self.parent.config_path,i['options']['ini']),command=i['options']['command'],args=i['options']['args'])
         if i['type'] == 'airspeed_dial':
             self.instruments[count] = airspeed.Airspeed(self)
         if i['type'] == 'airspeed_box':
@@ -164,7 +164,7 @@ class Screen(QWidget):
             self.instruments[count] = vsi.Alt_Trend_Tape(self)
         elif i['type'] == 'button':
             if 'options' in i and 'config' in i['options']:
-                self.instruments[count] = button.Button(self,config_file=os.path.join(self.parent.path,i['options']['config']))
+                self.instruments[count] = button.Button(self,config_file=os.path.join(self.parent.config_path,i['options']['config']))
             else:
                 logger.warn("button must specify options: config:") 
         elif i['type'] == 'heading_display':


### PR DESCRIPTION
This allows screen builder include files to be rendered relative to the row/column specified.
With this includes can be used on different screens and placed at different locations on the screen if desired.