### PR TITLE
Fix for #139

### DIFF
--- a/pyefis/config/includes/virtual_vfr.yaml
+++ b/pyefis/config/includes/virtual_vfr.yaml
@@ -18,7 +18,7 @@ instruments:
     options:
       #fontSize: 48
       font_percent: 0.05
-      fg_color: "#aaaaaa"
+      #fg_color: "#aaaaaa"
       bg_color: "#aaaaaa"
       cdi_enabled: true
       gsi_enabled: true

--- a/pyefis/screens/screenbuilder.py
+++ b/pyefis/screens/screenbuilder.py
@@ -82,7 +82,16 @@ class Screen(QWidget):
 
         self.init= False
 
-
+        # Hack to prevent exception at startup that happens
+        # when pyefis is started before fixgateway
+        loaded = False
+        while not loaded:
+            try:
+                fix.db.get_item("ZZLOADER")
+                loaded = True
+            except:
+                logger.critical("fix database not fully Initialized yet, ensure you have 'ZZLOADER' created in fixgateway database.yaml")
+                time.sleep(2)
         # list of dial types supported so far:
         # airspeed_dial
         # airspeed_trend_tape # Testing to do

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: pyefis
-version: "0.12.1"
+version: "0.14.0"
 grade: stable
 license: GPL-2.0+
 summary: pyEFIS Open Source Avionics Application
@@ -12,6 +12,9 @@ description: |
 
   This snap requires enabling experimental.user-daemons features:
   sudo snap set system experimental.user-daemons=true
+
+  Breaking Changes:
+  Ensure your fix gateway database.yaml file defines a db key named 'ZZLOADER', without this pyefis will not load.
 
   Release Notes:
   This is a beta release and has not seen much testing, if you find any bugs please report them here: https://github.com/makerplane/pyEfis/issues


### PR DESCRIPTION
Test that we can access the last db key before proceeding to load a screen. Prevents exception when pyefis is started before fix gateway.
