### PR TITLE
Updated snapcraft.yaml to consume the faa-cifp-data content snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: pyefis
-version: "2.0.1"
+version: "2.0.2"
 grade: stable
 license: GPL-2.0+
 summary: pyEFIS Open Source Avionics Application
@@ -74,6 +74,9 @@ layout:
     bind: $SNAP/etc/fonts
   /usr/share/fonts:
     bind: $SNAP/usr/share/fonts
+  /usr/share/makerplane/CIFP:
+    symlink: $SNAP/faa-cifp-data/CIFP
+
 parts:
   extras:
     source: ./extras
@@ -145,6 +148,11 @@ plugs:
     interface: content
     target: $SNAP/gpu-2404
     default-provider: mesa-2404
+
+  faa-cifp-data:
+    interface : content
+    target: $SNAP/faa-cifp-data
+    #default-provider: faa-cifp-data
 
 apps:
   daemon:


### PR DESCRIPTION
Before we can merge this we first need a new repo for faa-cifp-data snap so it can be published to snapcraft.io.