### PR TITLE
more preferences configuration

### DIFF
--- a/pyefis/cfg.py
+++ b/pyefis/cfg.py
@@ -59,6 +59,18 @@ def from_yaml(fname,bpath=None,cfg=None,bc=[],preferences=None):
                             if not os.path.exists(ifile):
                                 # Use base path
                                 ifile = bpath + '/' + l['include']
+                            if not os.path.exists(ifile):
+                                # Check preferences
+                                if 'includes' in preferences:
+                                    pfile = preferences['includes'].get(l['include'],False)
+                                    if pfile:
+                                        ifile = fpath + '/' + pfile
+                                        if not os.path.exists(ifile):
+                                            ifile = bpath + '/' + pfile
+                                            if not os.path.exists(ifile):
+                                                raise Exception(f"Cannot find include: {f}")
+                                else:
+                                    raise Exception(f"Cannot find include: {f}")
                             litems = yaml.safe_load(open(ifile))
                             if 'items' in litems:
                                 for a in litems['items']:

--- a/pyefis/cfg.py
+++ b/pyefis/cfg.py
@@ -73,8 +73,9 @@ def from_yaml(fname,bpath=None,cfg=None,bc=[],preferences=None):
                                     raise Exception(f"Cannot find include: {f}")
                             litems = yaml.safe_load(open(ifile))
                             if 'items' in litems:
-                                for a in litems['items']:
-                                    new[key].append(a)
+                                if litems['items'] != None:
+                                    for a in litems['items']:
+                                        new[key].append(a)
                             else:
                                 raise Exception(f"Error in {ifile}\nWhen including list items they need listed under 'items:' in the include file")
                         else:

--- a/pyefis/config/databindings/default.yaml
+++ b/pyefis/config/databindings/default.yaml
@@ -1,0 +1,56 @@
+# Data bindings allow mapping data changes to actions
+# If you have an idea for some defaults we should include here
+# pull requests on github are welcome!
+
+items:
+# These button examples map BTN1 and BTN2 to activating
+# the button of the legacy menu.
+# Since the legacy menu is disabled by default so are 
+# these mappings:
+#  - key: BTN1
+#    condition: True
+#    action: Activate Menu Item
+#    args: 1
+#  - key: BTN2
+#    condition: True
+#    action: Activate Menu Item
+#    args: 2
+
+# This encoder example is also for the legacy menu
+#  - key: ENC1
+#    action: Menu Encoder
+#    args: <VALUE>   # This sends the data value to the action
+
+# This is an example that could still be useful
+# Currently the EMS button is set to turn red under 
+# some conditions, a low oil pressure like this 
+# could be added to that button.
+# The button could also, instead of turning red take you to the 
+# EMS screen like this configuration would do
+# Basically this is just an alternative way to
+# do the same things we can do within buttons
+#  - key: OILP1
+#    condition: < 25
+#    action: Show Screen
+#    args: EMS
+
+# Currently the hmi action class:
+# pyefis/hmi/actionclass.py
+# Supports the following actions that could be used here:
+# "set airspeed mode":self.setAirspeedMode,
+# "set egt mode":self.setEgtMode,
+# "show screen":self.showScreen,
+# "show next screen":self.showNextScreen,
+# "show previous screen":self.showPrevScreen,
+# "set value":functions.setValue,
+# "change value":functions.changeValue,
+# "toggle bit":functions.toggleBool,
+# "activate menu item":self.activateMenuItem,
+# "activate menu":activateMenu,
+# "menu encoder":self.menuEncoder,
+# "set menu focus":self.setMenuFocus,
+# "set instrument units":self.setInstUnits,
+# "exit":self.doExit,
+#
+# The button instrument can also call these as actions
+

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -21,13 +21,8 @@ databindings:
 # of the point and send the data at half that interval.
 # OnChange will send when the value is changed and Both will
 # do both.
-#outputs:
-#  BARO: onchange
-#  TRIMP: onchange
-#  TRIMR: onchange
-#  TRIMY: onchange
-#  APREQ: onchange
-#  APADJ: onchange
+outputs:
+  - include: OUTPUTS_CONFIG
 
 # Screen definitions describe the screens that will be loaded
 # and ready for use.  Each section should start with "Screen."

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -101,12 +101,12 @@ keybindings:
 
 screens:
   include: 
-  - screens/sixpack.yaml
-  - screens/android.yaml
-  - screens/pfd.yaml
-  - screens/radio.yaml
-  - screens/ems.yaml
-  - screens/ems2.yaml
+  - SCREEN_SIXPACK
+  - SCREEN_ANDROID
+  - SCREEN_PFD
+  - SCREEN_RADIO
+  - SCREEN_EMS
+  - SCREEN_EMS2
  
 # Hooks are user defined modules that are loaded at specific points
 # in the programs execution.  Right now their is only one place and

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -1,4 +1,4 @@
-auto start: True
+auto start: AUTO_START
 # For help configuring your screen layout visit:
 # https://github.com/makerplane/pyEfis/blob/master/docs/screenbuilder.md
 main:

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -8,34 +8,7 @@ main:
 # a string that represents a key Sequence.  See the documentation for more
 # information about key sequences and actions.
 keybindings:
-  - key: X
-    action: exit
-
-  - key: A
-    action: Show Previous Screen
-
-  - key: S
-    action: Show Next Screen
-
-  - key: P
-    action: Show Screen
-    args: PFD
-
-  - key: M
-    action: Set Airspeed Mode
-
-  - key: "1"
-    action: Set EGT Mode
-    args: Normalize
-  - key: "2"
-    action: Set EGT Mode
-    args: Peak
-  - key: "3"
-    action: Set EGT Mode
-    args: Lean
-  - key: "4"
-    action: Set EGT Mode
-    args: Reset Peak
+  - include: KEYBINDING_CONFIG
 
 # Data bindings tie actions to values in teh database
 # key is the database key and should match the FIX Gateway key

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -121,41 +121,5 @@ hooks:
 
 
 # Logging configuration - See Python logging.config module documenation
-# Logging configuration - See Python logging.config module documenation
 logging:
-  version: 1
-  disable_existing_loggers: False
-  loggers:
-    '':
-      # messages with levels below the one given will not be logged
-      #level: DEBUG
-      level: INFO
-      #level: WARNING
-      #level: ERROR
-      #level: CRITICAL
-
-      handlers: [stderr] #, file]
-      propagate: True
-
-  formatters:
-    standard:
-      format: "%(levelname)s:%(asctime)s:%(name)s - %(message)s"
-      datefmt: "%Y%m%d-%H:%M:%S"
-      class: logging.Formatter
-
-  handlers:
-    stderr:
-      class: logging.StreamHandler
-      formatter: standard
-      stream: ext://sys.stderr
-
-#    file:
-#      class: logging.FileHandler
-#      formatter: standard
-#      filename: "{SNAP_USER_COMMON}fixgw.log"
-#      mode: w
-#      mode: a
-
-    syslog:
-      class: logging.handlers.SysLogHandler
-      formatter: standard
+  include: LOGGING_CONFIG

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -93,10 +93,6 @@ keybindings:
 #  APREQ: onchange
 #  APADJ: onchange
 
-# No need to change this.
-# To customize
-preferences: preferences.yaml
-
 # Screen definitions describe the screens that will be loaded
 # and ready for use.  Each section should start with "Screen."
 # followed by the name.  The only required configuration is

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -12,8 +12,8 @@ keybindings:
 
 # Data bindings tie actions to values in teh database
 # key is the database key and should match the FIX Gateway key
-#databindings:
-
+databindings:
+  - include: DATABINDING_CONFIG
 
 # This section defines FIX IDs that we'll write out to the
 # FIX Gateway server.  Each can be defined as one of three

--- a/pyefis/config/default.yaml
+++ b/pyefis/config/default.yaml
@@ -2,44 +2,7 @@ auto start: AUTO_START
 # For help configuring your screen layout visit:
 # https://github.com/makerplane/pyEfis/blob/master/docs/screenbuilder.md
 main:
-  # IP information for network adapter
-  FixServer: 127.0.0.1
-  FixPort: 3490
-
-  # Menu timeout in ms
-  # All this does is set fix key MENUITEM to True after a timeout
-  # Individual buttons need to have conditions that will show/hide the button
-  # based on the value of MENUITEM
-  # The main buttons included by default have such logic
-  # Uncomment the next line to enable this feature:
-  #button_timeout: 10000 
-
-  # Screen Geometry
-  # Defaults to screen size if screenWidth or screenHeight is not defined
-  #screenWidth: 1280
-  #screenHeight: 720
-  #screenWidth: 1024
-  #screenHeight: 768
-  #screenWidth: 1920
-  #screenHeight: 540
-  #screenHeight: 550
-  #screenHeight: 1080
-  #screenWidth: 640
-  #screenHeight: 480
-  #screenWidth: 3840
-  #screenHeight: 1100
-  # Set EFIS to occupy the entire screen without system border / menu
-  screenFullSize: True
-
-  # Screen background color RGB
-  screenColor: (0,0,0)
-
-  # If left out the first defined screen will be default
-  defaultScreen: PFD
-
-  # nodeID, currently only used in touchscreen buttons
-  # the value will replace {id} in the button's dbkey
-  nodeID: 1
+  include: MAIN_CONFIG
 
 # The keybindings are used to attach keystrokes to actions.  The key can be
 # a string that represents a key Sequence.  See the documentation for more

--- a/pyefis/config/keybindings/default.yaml
+++ b/pyefis/config/keybindings/default.yaml
@@ -1,0 +1,31 @@
+# List of default key bindings
+items:
+  - key: X
+    action: exit
+
+  - key: A
+    action: Show Previous Screen
+
+  - key: S
+    action: Show Next Screen
+
+  - key: P
+    action: Show Screen
+    args: PFD
+
+  - key: M
+    action: Set Airspeed Mode
+
+  - key: "1"
+    action: Set EGT Mode
+    args: Normalize
+  - key: "2"
+    action: Set EGT Mode
+    args: Peak
+  - key: "3"
+    action: Set EGT Mode
+    args: Lean
+  - key: "4"
+    action: Set EGT Mode
+    args: Reset Peak
+

--- a/pyefis/config/logging/file-debug.yaml
+++ b/pyefis/config/logging/file-debug.yaml
@@ -1,0 +1,36 @@
+  version: 1
+  disable_existing_loggers: False
+  loggers:
+    '':
+      # messages with levels below the one given will not be logged
+      level: DEBUG
+      #level: INFO
+      #level: WARNING
+      #level: ERROR
+      #level: CRITICAL
+
+      handlers: [stderr, file]
+      propagate: True
+
+  formatters:
+    standard:
+      format: "%(levelname)s:%(asctime)s:%(name)s - %(message)s"
+      datefmt: "%Y%m%d-%H:%M:%S"
+      class: logging.Formatter
+
+  handlers:
+    stderr:
+      class: logging.StreamHandler
+      formatter: standard
+      stream: ext://sys.stderr
+
+    file:
+      class: logging.FileHandler
+      formatter: standard
+      filename: "{SNAP_USER_COMMON}pyefis.log"
+      mode: a
+
+    syslog:
+      class: logging.handlers.SysLogHandler
+      formatter: standard
+

--- a/pyefis/config/logging/stderr-debug.yaml
+++ b/pyefis/config/logging/stderr-debug.yaml
@@ -1,0 +1,37 @@
+  version: 1
+  disable_existing_loggers: False
+  loggers:
+    '':
+      # messages with levels below the one given will not be logged
+      level: DEBUG
+      #level: INFO
+      #level: WARNING
+      #level: ERROR
+      #level: CRITICAL
+
+      handlers: [stderr] #, file]
+      propagate: True
+
+  formatters:
+    standard:
+      format: "%(levelname)s:%(asctime)s:%(name)s - %(message)s"
+      datefmt: "%Y%m%d-%H:%M:%S"
+      class: logging.Formatter
+
+  handlers:
+    stderr:
+      class: logging.StreamHandler
+      formatter: standard
+      stream: ext://sys.stderr
+
+#    file:
+#      class: logging.FileHandler
+#      formatter: standard
+#      filename: "{SNAP_USER_COMMON}pyefis.log"
+#      mode: w
+#      mode: a
+
+    syslog:
+      class: logging.handlers.SysLogHandler
+      formatter: standard
+

--- a/pyefis/config/logging/stderr-info.yaml
+++ b/pyefis/config/logging/stderr-info.yaml
@@ -1,0 +1,37 @@
+  version: 1
+  disable_existing_loggers: False
+  loggers:
+    '':
+      # messages with levels below the one given will not be logged
+      #level: DEBUG
+      level: INFO
+      #level: WARNING
+      #level: ERROR
+      #level: CRITICAL
+
+      handlers: [stderr] #, file]
+      propagate: True
+
+  formatters:
+    standard:
+      format: "%(levelname)s:%(asctime)s:%(name)s - %(message)s"
+      datefmt: "%Y%m%d-%H:%M:%S"
+      class: logging.Formatter
+
+  handlers:
+    stderr:
+      class: logging.StreamHandler
+      formatter: standard
+      stream: ext://sys.stderr
+
+#    file:
+#      class: logging.FileHandler
+#      formatter: standard
+#      filename: "{SNAP_USER_COMMON}pyefis.log"
+#      mode: w
+#      mode: a
+
+    syslog:
+      class: logging.handlers.SysLogHandler
+      formatter: standard
+

--- a/pyefis/config/main/default.yaml
+++ b/pyefis/config/main/default.yaml
@@ -1,0 +1,35 @@
+  # IP information for network adapter
+  FixServer: 127.0.0.1
+  FixPort: 3490
+
+  # nodeID, currently only used in touchscreen buttons
+  # the value will replace {id} in the button's dbkey
+  nodeID: 1
+
+  # Menu timeout in ms
+  # All this does is set fix key MENUITEM to True after a timeout
+  # Individual buttons need to have conditions that will show/hide the button
+  # based on the value of MENUITEM
+  # The main buttons included by default have such logic
+  # Uncomment the next line to enable this feature:
+  #button_timeout: 10000 
+
+  # Screen Geometry
+  # Defaults to screen size if screenWidth or screenHeight is not defined
+  #screenWidth: 1280
+  #screenHeight: 720
+  #screenWidth: 1024
+  #screenHeight: 768
+  #screenWidth: 1920
+  #screenHeight: 1080
+
+  # Set EFIS to occupy the entire screen without system border / menu
+  screenFullSize: True
+
+  # Screen background color RGB
+  screenColor: (0,0,0)
+
+  # If left out the first defined screen will be default
+  defaultScreen: PFD
+
+

--- a/pyefis/config/outputs/default.yaml
+++ b/pyefis/config/outputs/default.yaml
@@ -1,0 +1,15 @@
+# Here would can set a list of fixids to
+# have their values sent to the FIX Gateway 
+# whenever the value changes ( onchange )
+# or at an interval ( interval )
+# This is necessary whenever data is changed and pyefis 
+# AND you want that data avaliable to the FIX Gateway
+# or other things connected to the gateway.
+#
+# Currently the default screen buttons that change data
+# do not require this feature. if a button changes a value
+# it always outputs that value
+
+items:
+#  BARO: onchange
+#  MYCUSTOMKEY: interval

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -96,7 +96,7 @@ enabled:
 # portion of the screen so you can customize as needed easily
 includes:
   BUTTON_GROUP1: includes/buttons/vertical/screen_changing_PFD-EMS-EMS2-ANDROID-RADIO-SIXPACK-Units.yaml
-
+  HMI_ENCODER_BUTTONS: hmi/encoder_input.yaml
 # Here you can customize individual gauges on the screen
 # Maybe you want to display MAXCHT1 instead of H2OT1
 # You can make such changes in this section

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -95,8 +95,19 @@ enabled:
 # Here you can define what include files are used to render some
 # portion of the screen so you can customize as needed easily
 includes:
+  # The include for the main navigations buttons:
   BUTTON_GROUP1: includes/buttons/vertical/screen_changing_PFD-EMS-EMS2-ANDROID-RADIO-SIXPACK-Units.yaml
+  # The include for the encoder button control feature
   HMI_ENCODER_BUTTONS: hmi/encoder_input.yaml
+  # The screen config files to load for the various default screens:
+  SCREEN_SIXPACK: screens/sixpack.yaml
+  SCREEN_ANDROID: screens/android.yaml
+  SCREEN_PFD: screens/pfd.yaml
+  SCREEN_RADIO: screens/radio.yaml
+  SCREEN_EMS: screens/ems.yaml
+  SCREEN_EMS2: screens/ems2.yaml
+
+
 # Here you can customize individual gauges on the screen
 # Maybe you want to display MAXCHT1 instead of H2OT1
 # You can make such changes in this section

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -106,7 +106,8 @@ includes:
   SCREEN_RADIO: screens/radio.yaml
   SCREEN_EMS: screens/ems.yaml
   SCREEN_EMS2: screens/ems2.yaml
-
+  # Include file for logging configuration
+  LOGGING_CONFIG: logging/stderr-info.yaml
 
 # Here you can customize individual gauges on the screen
 # Maybe you want to display MAXCHT1 instead of H2OT1

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -102,6 +102,8 @@ includes:
   KEYBINDING_CONFIG: keybindings/default.yaml
   # The databinding section of the configuration
   DATABINDING_CONFIG: databindings/default.yaml
+  # The outputs section of the configuration:
+  OUTPUTS_CONFIG: outputs/default.yaml
   # The include for the main navigations buttons:
   BUTTON_GROUP1: includes/buttons/vertical/screen_changing_PFD-EMS-EMS2-ANDROID-RADIO-SIXPACK-Units.yaml
   # The include for the encoder button control feature

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -98,6 +98,8 @@ enabled:
 includes:
   # The main section of the configuration
   MAIN_CONFIG: main/default.yaml
+  # The keybinding section of the configuration
+  KEYBINDING_CONFIG: keybindings/default.yaml
   # The include for the main navigations buttons:
   BUTTON_GROUP1: includes/buttons/vertical/screen_changing_PFD-EMS-EMS2-ANDROID-RADIO-SIXPACK-Units.yaml
   # The include for the encoder button control feature

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -100,6 +100,8 @@ includes:
   MAIN_CONFIG: main/default.yaml
   # The keybinding section of the configuration
   KEYBINDING_CONFIG: keybindings/default.yaml
+  # The databinding section of the configuration
+  DATABINDING_CONFIG: databindings/default.yaml
   # The include for the main navigations buttons:
   BUTTON_GROUP1: includes/buttons/vertical/screen_changing_PFD-EMS-EMS2-ANDROID-RADIO-SIXPACK-Units.yaml
   # The include for the encoder button control feature

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -68,6 +68,7 @@ styles:
 # Here you can enable or disble individual controls or gauges
 # 
 enabled:
+  AUTO_START: true
   DEMO_TESTING_TEXT: false
   VERSION_DISPLAY: true
   AIRCRAFT_IDENTIFIER: true

--- a/pyefis/config/preferences.yaml
+++ b/pyefis/config/preferences.yaml
@@ -96,6 +96,8 @@ enabled:
 # Here you can define what include files are used to render some
 # portion of the screen so you can customize as needed easily
 includes:
+  # The main section of the configuration
+  MAIN_CONFIG: main/default.yaml
   # The include for the main navigations buttons:
   BUTTON_GROUP1: includes/buttons/vertical/screen_changing_PFD-EMS-EMS2-ANDROID-RADIO-SIXPACK-Units.yaml
   # The include for the encoder button control feature

--- a/pyefis/config/screens/android-left-buttons.yaml
+++ b/pyefis/config/screens/android-left-buttons.yaml
@@ -2,7 +2,7 @@ ANDROID:
   module: pyefis.screens.screenbuilder
   title: Screen Builder
   include:
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   layout:
     #draw_grid: true
     rows: 110

--- a/pyefis/config/screens/android.yaml
+++ b/pyefis/config/screens/android.yaml
@@ -2,7 +2,7 @@ ANDROID:
   module: pyefis.screens.screenbuilder
   title: Screen Builder
   include:
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   layout:
     #draw_grid: true
     rows: 110

--- a/pyefis/config/screens/ems-left-buttons.yaml
+++ b/pyefis/config/screens/ems-left-buttons.yaml
@@ -1,7 +1,7 @@
 EMS:
   include:
   - screens/virtualvfr_db.yaml
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   module: pyefis.screens.screenbuilder
   title: Engine Management New
   layout:

--- a/pyefis/config/screens/ems.yaml
+++ b/pyefis/config/screens/ems.yaml
@@ -1,7 +1,7 @@
 EMS:
   include:
   - screens/virtualvfr_db.yaml
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   module: pyefis.screens.screenbuilder
   title: Engine Management New
   layout:

--- a/pyefis/config/screens/ems2-left-buttons.yaml
+++ b/pyefis/config/screens/ems2-left-buttons.yaml
@@ -1,5 +1,5 @@
 EMS2:
-  include: hmi/encoder_input.yaml
+  include: HMI_ENCODER_BUTTONS
   module: pyefis.screens.screenbuilder
   title: Engine Management New
   layout:

--- a/pyefis/config/screens/ems2.yaml
+++ b/pyefis/config/screens/ems2.yaml
@@ -1,5 +1,5 @@
 EMS2:
-  include: hmi/encoder_input.yaml
+  include: HMI_ENCODER_BUTTONS
   module: pyefis.screens.screenbuilder
   title: Engine Management New
   layout:

--- a/pyefis/config/screens/pfd-left-buttons.yaml
+++ b/pyefis/config/screens/pfd-left-buttons.yaml
@@ -2,7 +2,7 @@
 PFD:
   include:
   - screens/virtualvfr_db.yaml
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
     #refresh_period: 0.25
   module: pyefis.screens.screenbuilder
   title: Screen Builder

--- a/pyefis/config/screens/pfd.yaml
+++ b/pyefis/config/screens/pfd.yaml
@@ -2,7 +2,7 @@
 PFD:
   include:
   - screens/virtualvfr_db.yaml
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
     #refresh_period: 0.25
   module: pyefis.screens.screenbuilder
   title: Screen Builder

--- a/pyefis/config/screens/radio-left-buttons.yaml
+++ b/pyefis/config/screens/radio-left-buttons.yaml
@@ -4,7 +4,7 @@
 RADIO:
   include:
   - screens/virtualvfr_db.yaml
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   module: pyefis.screens.screenbuilder
   title: Radio Screen
   layout:

--- a/pyefis/config/screens/radio.yaml
+++ b/pyefis/config/screens/radio.yaml
@@ -4,7 +4,7 @@
 RADIO:
   include:
   - screens/virtualvfr_db.yaml
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   module: pyefis.screens.screenbuilder
   title: Radio Screen
   layout:

--- a/pyefis/config/screens/sixpack-left-buttons.yaml
+++ b/pyefis/config/screens/sixpack-left-buttons.yaml
@@ -2,7 +2,7 @@ SIXPACK:
   module: pyefis.screens.screenbuilder
   title: Standard Instrument Panel New
   include:
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   layout:
     rows: 110
     columns: 200

--- a/pyefis/config/screens/sixpack.yaml
+++ b/pyefis/config/screens/sixpack.yaml
@@ -2,7 +2,7 @@ SIXPACK:
   module: pyefis.screens.screenbuilder
   title: Standard Instrument Panel New
   include:
-  - hmi/encoder_input.yaml
+  - HMI_ENCODER_BUTTONS
   layout:
     rows: 110
     columns: 200

--- a/pyefis/hmi/data.py
+++ b/pyefis/hmi/data.py
@@ -119,6 +119,7 @@ class DataBinding(object):
 
 
 def initialize(config):
+    if config == None: return
     for x in config:
         try:
             d = DataBinding(x)

--- a/pyefis/main.py
+++ b/pyefis/main.py
@@ -162,8 +162,7 @@ def main():
         # Reset this stuff like we found it
         config_file = "{USER}/makerplane/pyefis/config/{FILE}".format(USER=user_home, FILE=config_filename)
     config_path = os.path.dirname(config_file)
-    config = cfg.from_yaml(config_file)
-    preference_file = f"{config_path}/{config.get('preferences','preferences.yaml')}"
+    preference_file = f"{config_path}/preferences.yaml"
     with open(preference_file) as cf:
        preferences = yaml.safe_load(cf)
     preference_file = preference_file + ".custom"
@@ -172,6 +171,9 @@ def main():
         with open(preference_file) as cf:
             custom = yaml.safe_load(cf)
         merge_dict(preferences,custom)
+
+    config = cfg.from_yaml(config_file,preferences=preferences)
+
     # If running under systemd
     if environ.get('INVOCATION_ID', False):
         # and autostart is not true, exit

--- a/pyefis/main.py
+++ b/pyefis/main.py
@@ -177,7 +177,20 @@ def main():
     # If running under systemd
     if environ.get('INVOCATION_ID', False):
         # and autostart is not true, exit
-        if not config.get('auto start', False): os._exit(0)
+        auto = config.get('auto start', False)
+        print(auto)
+        if isinstance(auto, str):
+            # Check preferecnes
+            if 'enabled' in preferences:
+                if not preferences['enabled'].get('AUTO_START', False):
+                    os._exit(0)
+            else:
+                # It is a string and we we cannot lookup enabled keys in preferences
+                # Assume false
+                os._exit(0)
+        elif not auto:
+            os._exit(0)
+
 
     log_config_file = args.log_config if args.log_config else config_file
 

--- a/pyefis/version.py
+++ b/pyefis/version.py
@@ -1,3 +1,3 @@
-VERSION="2.0.13"
+VERSION="2.0.14"
 print(VERSION)
 


### PR DESCRIPTION
Allow using preferences in the default.yaml or anything it includes
Updated default.yaml so every section is its own preference config
It should be possible, in most cases, to customize pyefis by editing preferences.yaml.custom and in some cases also adding some new custom yaml file for something not included in the default config examples. 
