### PR TITLE
On RPi Bookworm use PyQt6 installed system wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@
 doc/_*
 .ropeproject/*
 .directory
+config/
 
 # IDE artifacts
 .vscode/
+.code-worksapce
 
 ### Python template
 # Byte-compiled / optimized / DLL files
@@ -24,9 +26,14 @@ __pycache__/
 # C extensions
 *.so
 
+# Virtual environments
+env/
+venv/
+.venv/
+ENV/
+
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -70,9 +77,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
-
-# Python virtual env
-venv/
 
 # Makefile markers
 *.marker

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,87 @@
 ################################
-#    Makefile for pyavtools    #
+#    Makefile for pyefis       #
 ################################
 SHELL := /bin/bash
 
 
 ##################################### I N I T   T A R G E T S #####################################
 venv.marker:
-	python3 -m venv venv
-	source venv/bin/activate ; pip install --upgrade pip
-	source venv/bin/activate ; pip install black
-	source venv/bin/activate ; pip install pytest
-	source venv/bin/activate ; pip install pytest-qt
-	source venv/bin/activate ; pip install pytest-env
-	source venv/bin/activate ; pip install pytest-cov
+	@if grep -qi 'Raspberry Pi' /proc/cpuinfo && grep -qi 'bookworm' /etc/os-release; then \
+	    echo "Detected Raspberry Pi running Bookworm, will use --system-site-packages"; \
+            echo "Checking if PyQt6 is installed system-wide..."; \
+            if ! python3 -c 'import PyQt6' >/dev/null 2>&1; then \
+                echo >&2 "Error: PyQt6 is not installed. Please run: sudo apt install python3-pyqt6"; \
+                exit 1; \
+	    else \
+	        echo "...PyQt6 is installed system-wide"; \
+            fi; \
+	    echo "Any WARNINGS related to system-site-packages (eg. send2trash) can be ignored"; \
+	    python3 -m venv venv --system-site-packages; \
+	else \
+	    echo "Standard environment, creating isolated venv, PyQt6 will be installed via pip when running 'make init'"; \
+	    python3 -m venv venv; \
+	fi
+	venv/bin/pip install --upgrade pip
+	venv/bin/pip install --upgrade send2trash
+	venv/bin/pip install black
+	venv/bin/pip install pytest
+	venv/bin/pip install pytest-qt
+	venv/bin/pip install pytest-env
+	venv/bin/pip install pytest-cov
 	touch venv.marker
-	echo -e "\nRun:\nsource venv/bin/activate"
+	echo -e "\nRun:\nsource venv/bin/activate (you may also have to add ';export DISPLAY=:0' if any display errors are encountered)"
 venv: venv.marker
 .PHONY: venv
 
 init.marker: pyproject.toml
-	source venv/bin/activate ; pip install -e .[install]
+	@if grep -qi 'Raspberry Pi' /proc/cpuinfo && grep -qi 'bookworm' /etc/os-release; then \
+	    echo "Detected Raspberry Pi running Bookworm, will use the system installed PyQt6 version"; \
+	    echo "Checking if PyQt6 is installed system-wide..."; \
+	    if ! python3 -c 'import PyQt6' >/dev/null 2>&1; then \
+		echo >&2 "Error: PyQt6 is not installed. Please run: sudo apt install python3-pyqt6"; \
+		exit 1; \
+	    else \
+		echo "...PyQt6 is installed system-wide"; \
+	    fi; \
+	    echo "Checking if 'xwininfo' (from x11-utils) is installed..."; \
+	    if ! command -v xwininfo >/dev/null 2>&1; then \
+		echo >&2 "Error: xwininfo not found. Please run: sudo apt install x11-utils"; \
+		exit 1; \
+	    else \
+		echo "...xwininfo is installed"; \
+	    fi; \
+	    venv/bin/pip install -e .[install]; \
+	else \
+	    echo "Standard environment found, will install PyQt6 via PyPI"; \
+	    venv/bin/pip install -e .[qt]; \
+	fi
 	touch init.marker
 init: venv.marker init.marker
 .PHONY: init
 
 #################################### W H E E L   T A R G E T S ####################################
 init-build.marker: init
-	source venv/bin/activate ; pip install -e .[build]
+	venv/bin/pip install -e .[build]
 	touch init-build.marker
 
 init-build: init-build.marker
 .PHONY: init-build
 
 wheel: init-build
-	source venv/bin/activate ; python -m build --wheel
+	venv/bin/python -m build --wheel
 
 
 test: init
-	source venv/bin/activate ; pytest
+	venv/bin/pytest
 
 .PHONY: test
 
 clean:
-	rm -rfI venv || true
-	rm -fI extras/extras/test_results/*.html || true
-	rm -fI extras/extras/test_results/*.png || true
-	rm -rfI extras/extras/test_results/htmlcov/ || true
-	rm -f init-build.marker || true
-	rm -f init.marker || true
-	rm -f venv.marker || true
+	rm -rf venv
+	rm -f extras/extras/test_results/*.html
+	rm -f extras/extras/test_results/*.png
+	rm -rf extras/extras/test_results/htmlcov/
+	rm -f init-build.marker
+	rm -f init.marker
+	rm -f venv.marker
 .PHONY: clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 # Until this revision is published to PyPy get it from git:
     "pyavtools @ git+https://github.com/makerplane/pyAvTools/@b3a4c05f0379f751fff8e2080431eff5ba13f8f1",
     "pycond==20230212",
-    "PyQt6==6.8.0",
+    # "PyQt6==6.8.0",
     "PyYAML==6.0.1",
     "python-xlib==0.33"
 ]
@@ -49,6 +49,9 @@ dependencies = [
 [project.optional-dependencies]
 build = [
     "build==1.2.1",
+]
+qt = [
+    "PyQt6==6.8.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Makefile mods to check the local build environment and if Bookworm on RPi then reference the system PyQt6 installation; some additional .gitignore items.